### PR TITLE
[BE] 로그인 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:8.5-jdk21 as build
+
+WORKDIR /app
+
+COPY . .
+RUN gradle clean build -x test --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
-
-    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: auratalk-app
+    ports:
+      - "${SERVER_PORT}:${SERVER_PORT}"
+    depends_on:
+      - db
+      - redis
+    env_file:
+      - .env
+    environment:
+      - SPRING_DATASOURCE_URL=${DB_URL}
+      - SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=${JPA_DDL_AUTO}
+      - SPRING_JPA_SHOW_SQL=${SHOW_SQL}
+      - SPRING_DATA_REDIS_HOST=${REDIS_HOST}
+      - SPRING_DATA_REDIS_PORT=${REDIS_PORT}
+      - SPRING_DATA_REDIS_PASSWORD=${REDIS_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=${JWT_EXPIRATION}
+    restart: always
+    networks:
+      - auratalk-network
+
+  db:
+    image: mysql:8.0
+    container_name: auratalk-db
+    ports:
+      - "${DB_PORT}:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-data:/var/lib/mysql
+    restart: always
+    networks:
+      - auratalk-network
+
+  redis:
+    image: redis:7.0
+    container_name: auratalk-redis
+    ports:
+      - "${REDIS_PORT}:6379"
+    restart: always
+    networks:
+      - auratalk-network
+
+networks:
+  auratalk-network:
+    driver: bridge
+
+volumes:
+  mysql-data:

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.sonsminpark.auratalkback.domain.user.controller;
+
+import com.sonsminpark.auratalkback.domain.user.dto.request.LoginRequestDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
+import com.sonsminpark.auratalkback.domain.user.service.UserService;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 통해 로그인합니다.")
+    public ResponseEntity<ApiResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+        LoginResponseDto loginResponseDto = userService.login(loginRequestDto);
+        return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", loginResponseDto));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7);
+        userService.logout(token);
+        return ResponseEntity.ok(ApiResponse.success("로그아웃에 성공했습니다."));
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/LoginRequestDto.java
@@ -1,0 +1,22 @@
+package com.sonsminpark.auratalkback.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/UserDto.java
@@ -1,0 +1,79 @@
+package com.sonsminpark.auratalkback.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserDto {
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUpRequest {
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @Size(min = 6, message = "비밀번호는 6자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+                message = "비밀번호는 대소문자, 특수문자, 숫자를 포함해야 합니다.")
+        private String password;
+
+        @NotBlank(message = "사용자명은 필수 입력값입니다.")
+        @Size(min = 3, max = 15, message = "사용자명은 3자 이상 15자 이하이어야 합니다.")
+        @Pattern(regexp = "^[^\\s]+$", message = "사용자명에 공백을 포함할 수 없습니다.")
+        private String username;
+
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Size(min = 1, max = 15, message = "닉네임은 1자 이상 15자 이하이어야 합니다.")
+        @Pattern(regexp = "^[^\\s]+$", message = "닉네임에 공백을 포함할 수 없습니다.")
+        private String nickname;
+
+        private List<String> interests;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginRequest {
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        private String password;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateRequest {
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Size(min = 1, max = 15, message = "닉네임은 1자 이상 15자 이하이어야 합니다.")
+        @Pattern(regexp = "^[^\\s]+$", message = "닉네임에 공백을 포함할 수 없습니다.")
+        private String nickname;
+
+        private List<String> interests;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenResponse {
+        private String accessToken;
+        private String tokenType;
+        private Long expiresIn;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/LoginResponseDto.java
@@ -1,0 +1,18 @@
+package com.sonsminpark.auratalkback.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponseDto {
+    private Long userId;
+    private String email;
+    private String username;
+    private String nickname;
+    private String accessToken;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/LoginResponseDto.java
@@ -10,9 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class LoginResponseDto {
-    private Long userId;
-    private String email;
-    private String username;
-    private String nickname;
-    private String accessToken;
+    private String token;
+    private UserResponseDto user;
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
@@ -1,0 +1,38 @@
+package com.sonsminpark.auratalkback.domain.user.dto.response;
+
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.entity.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponseDto {
+
+    private Long id;
+    private String email;
+    private String username;
+    private String nickname;
+    private List<String> interests;
+    private UserStatus status;
+    private LocalDateTime createdAt;
+
+    public static UserResponseDto from(User user) {
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .interests(user.getInterests())
+                .status(user.getStatus())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
@@ -3,7 +3,6 @@ package com.sonsminpark.auratalkback.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -48,7 +47,6 @@ public class User {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    @CreationTimestamp
     private LocalDateTime deletedAt;
 
     public void updateStatus(UserStatus status) {
@@ -57,6 +55,7 @@ public class User {
 
     public void delete() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void update(String nickname, List<String> interests) {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
@@ -1,0 +1,66 @@
+package com.sonsminpark.auratalkback.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 15)
+    private String username;
+
+    @Column(nullable = false, length = 15)
+    private String nickname;
+
+    @ElementCollection
+    @CollectionTable(name = "user_interests", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "interest")
+    private List<String> interests = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    @CreationTimestamp
+    private LocalDateTime deletedAt;
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    public void update(String nickname, List<String> interests) {
+        this.nickname = nickname;
+        this.interests = interests;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserStatus.java
@@ -1,0 +1,7 @@
+package com.sonsminpark.auratalkback.domain.user.entity;
+
+public enum UserStatus {
+    ONLINE,     // 온라인
+    OFFLINE,    // 오프라인
+    SECRET      // 비공개
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/DuplicateUserException.java
@@ -1,0 +1,30 @@
+package com.sonsminpark.auratalkback.domain.user.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+/**
+ * 사용자 정보(이메일, 사용자명, 닉네임 등)가 중복될 때 발생하는 예외
+ */
+public class DuplicateUserException extends BusinessException {
+
+    public DuplicateUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicateUserException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public static DuplicateUserException ofEmail(String email) {
+        return new DuplicateUserException(ErrorCode.DUPLICATE_EMAIL, "이미 사용 중인 이메일입니다: " + email);
+    }
+
+    public static DuplicateUserException ofUsername(String username) {
+        return new DuplicateUserException(ErrorCode.DUPLICATE_USERNAME, "이미 사용 중인 사용자명입니다: " + username);
+    }
+
+    public static DuplicateUserException ofNickname(String nickname) {
+        return new DuplicateUserException(ErrorCode.DUPLICATE_NICKNAME, "이미 사용 중인 닉네임입니다: " + nickname);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserCredentialsException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserCredentialsException.java
@@ -1,0 +1,17 @@
+package com.sonsminpark.auratalkback.domain.user.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+/**
+ * 사용자 인증 정보가 잘못되었을 때 발생하는 예외
+ */
+public class InvalidUserCredentialsException extends BusinessException {
+    public InvalidUserCredentialsException() {
+        super(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    public InvalidUserCredentialsException(String message) {
+        super(ErrorCode.INVALID_CREDENTIALS, message);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,25 @@
+package com.sonsminpark.auratalkback.domain.user.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+/**
+ * 사용자를 찾을 수 없을 때 발생하는 예외
+ */
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+
+    public UserNotFoundException(String message) {
+        super(ErrorCode.USER_NOT_FOUND, message);
+    }
+
+    public UserNotFoundException(Long userId) {
+        super(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다. ID: " + userId);
+    }
+
+    public UserNotFoundException(String email, String reason) {
+        super(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다. 이메일: " + email + ", 이유: " + reason);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.sonsminpark.auratalkback.domain.user.repository;
+
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmailAndIsDeletedFalse(String email);
+
+    boolean existsByEmailAndIsDeletedFalse(String email);
+
+    boolean existsByUsernameAndIsDeletedFalse(String username);
+
+    boolean existsByNicknameAndIsDeletedFalse(String nickname);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.request.LoginRequestDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
+
+public interface UserService {
+    LoginResponseDto login(LoginRequestDto loginRequestDto);
+    void logout(String token);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,70 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.request.LoginRequestDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.UserResponseDto;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.entity.UserStatus;
+import com.sonsminpark.auratalkback.domain.user.exception.InvalidUserCredentialsException;
+import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    @Transactional
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
+
+        User user = userRepository.findByEmailAndIsDeletedFalse(loginRequestDto.getEmail())
+                .orElseThrow(() -> new UserNotFoundException(loginRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
+            throw new InvalidUserCredentialsException("이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 로그인 시 ONLINE으로 변경
+        user.updateStatus(UserStatus.ONLINE);
+
+        String token = jwtTokenProvider.createToken(user.getEmail());
+
+        UserResponseDto userResponseDto = UserResponseDto.from(user);
+
+        return LoginResponseDto.builder()
+                .token(token)
+                .user(userResponseDto)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void logout(String token) {
+
+        String email = jwtTokenProvider.getEmailFromToken(token);
+
+
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new UserNotFoundException(email, "존재하지 않는 사용자입니다."));
+
+        // 로그아웃 시 OFFLINE으로 변경
+        user.updateStatus(UserStatus.OFFLINE);
+
+        // 토큰 블랙리스트에 추가
+        long validityInMilliseconds = jwtTokenProvider.getTokenValidityInMilliseconds();
+        redisTemplate.opsForValue().set("BLACKLIST:" + token, "logout", validityInMilliseconds, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -9,13 +9,11 @@ import com.sonsminpark.auratalkback.domain.user.exception.InvalidUserCredentials
 import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
 import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
 import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import com.sonsminpark.auratalkback.global.security.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +22,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     @Transactional
@@ -64,7 +62,6 @@ public class UserServiceImpl implements UserService {
         user.updateStatus(UserStatus.OFFLINE);
 
         // 토큰 블랙리스트에 추가
-        long validityInMilliseconds = jwtTokenProvider.getTokenValidityInMilliseconds();
-        redisTemplate.opsForValue().set("BLACKLIST:" + token, "logout", validityInMilliseconds, TimeUnit.MILLISECONDS);
+        tokenBlacklistService.addToBlacklist(token, jwtTokenProvider.getTokenValidityInMilliseconds());
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/global/common/ApiResponse.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/common/ApiResponse.java
@@ -1,0 +1,73 @@
+package com.sonsminpark.auratalkback.global.common;
+
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApiResponse<T> {
+    private boolean success;
+    private int code;
+    private String message;
+    private T data;
+
+    // 성공 응답 생성
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(200) // 성공 코드는 200으로 통일
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 간단한 성공 응답 생성 (데이터 없음)
+    public static ApiResponse<Void> success(String message) {
+        return success(message, null);
+    }
+
+    // 예외 코드만 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .data(null)
+                .build();
+    }
+
+    // 예외 코드와 데이터를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    // 예외 코드와 사용자 정의 메시지를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(message != null ? message : errorCode.getMessage())
+                .data(null)
+                .build();
+    }
+
+    // 예외 코드, 사용자 정의 메시지, 데이터를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(message != null ? message : errorCode.getMessage())
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/RedisConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.sonsminpark.auratalkback.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+        if (password != null && !password.isEmpty()) {
+            redisConfig.setPassword(password);
+        }
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -41,7 +43,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/ai/**").authenticated()
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger
                                 .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -2,10 +2,10 @@ package com.sonsminpark.auratalkback.global.config;
 
 import com.sonsminpark.auratalkback.global.jwt.JwtAuthenticationFilter;
 import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import com.sonsminpark.auratalkback.global.security.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,7 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -43,7 +43,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/ai/**").authenticated()
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger
                                 .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistService),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.sonsminpark.auratalkback.global.config;
+
+import com.sonsminpark.auratalkback.global.jwt.JwtAuthenticationFilter;
+import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/api/users/login", "/api/users", "/api/users/logout").permitAll()
+                                .requestMatchers("/api/users/**").authenticated()
+                                .requestMatchers("/api/friends/**").authenticated()
+                                .requestMatchers("/api/chats/**").authenticated()
+                                .requestMatchers("/api/chatrooms/**").authenticated()
+                                .requestMatchers("/api/notifications/**").authenticated()
+                                .requestMatchers("/api/ai/**").authenticated()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger
+                                .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/exception/BusinessException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/exception/BusinessException.java
@@ -1,0 +1,32 @@
+package com.sonsminpark.auratalkback.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    // 기본 생성자
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    // 사용자 정의 메시지가 있는 생성자
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    // 원인 예외가 있는 생성자
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    // 사용자 정의 메시지와 원인 예외가 있는 생성자
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/exception/ErrorCode.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/exception/ErrorCode.java
@@ -1,0 +1,65 @@
+package com.sonsminpark.auratalkback.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 코드 규칙
+ * - 4xx: 클라이언트 에러
+ *   - 400~409: 일반적인 요청 에러
+ *   - 410~419: 인증/인가 관련 에러
+ *   - 420~429: 사용자 관련 에러
+ *   - 430~439: 친구 관련 에러
+ *   - 440~449: 채팅 관련 에러
+ * - 5xx: 서버 에러
+ *   - 500~509: 일반적인 서버 에러
+ *   - 510~519: 데이터베이스 관련 에러
+ */
+@Getter
+public enum ErrorCode {
+
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 400, "입력값이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 401, "허용되지 않은 메서드입니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, 402, "잘못된 타입의 값입니다."),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, 403, "필수 요청 파라미터가 누락되었습니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "엔티티를 찾을 수 없습니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, 405, "지원하지 않는 미디어 타입입니다."),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 410, "인증이 필요합니다."),
+    INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, 411, "잘못된 인증 토큰입니다."),
+    EXPIRED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, 412, "만료된 인증 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, 413, "접근이 거부되었습니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 420, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 421, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, 422, "이미 사용 중인 사용자명입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, 423, "이미 사용 중인 닉네임입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, 424, "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, 430, "친구를 찾을 수 없습니다."),
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, 431, "친구 요청을 찾을 수 없습니다."),
+    DUPLICATE_FRIEND_REQUEST(HttpStatus.CONFLICT, 432, "이미 친구 요청을 보냈습니다."),
+    ALREADY_FRIEND(HttpStatus.CONFLICT, 433, "이미 친구입니다."),
+
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 440, "채팅방을 찾을 수 없습니다."),
+    CHAT_ACCESS_DENIED(HttpStatus.FORBIDDEN, 441, "채팅방에 접근할 권한이 없습니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 442, "채팅 메시지를 찾을 수 없습니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 501, "서비스를 사용할 수 없습니다."),
+
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 510, "데이터베이스 오류가 발생했습니다."),
+
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 520, "파일 업로드 중 오류가 발생했습니다."),
+    FILE_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 521, "파일 다운로드 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, int code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package com.sonsminpark.auratalkback.global.exception;
+
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 로직 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("BusinessException: code={}, message={}", errorCode.getCode(), e.getMessage(), e);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode, e.getMessage()));
+    }
+
+    // 입력값 유효성 검사 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        Map<String, String> errors = new HashMap<>();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        log.error("Validation error: {}", errors);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, "입력값 검증에 실패했습니다.", errors));
+    }
+
+    // 메서드 인자 타입 불일치 예외 처리
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex) {
+        log.error("Type mismatch: {}", ex.getMessage(), ex);
+        String message = String.format("잘못된 타입의 값이 입력되었습니다. '%s' 필드에는 '%s' 타입이 필요합니다.",
+                ex.getName(), ex.getRequiredType() != null ? ex.getRequiredType().getSimpleName() : "알 수 없음");
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_TYPE_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_TYPE_VALUE, message));
+    }
+
+    // 기타 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleAllExceptions(Exception e) {
+        log.error("Unexpected error occurred: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -18,19 +19,27 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String token = resolveToken(request);
 
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.debug("Set Authentication to security context for '{}', uri: {}",
-                    authentication.getName(), request.getRequestURI());
+        if (StringUtils.hasText(token)) {
+            String blacklistedToken = redisTemplate.opsForValue().get("BLACKLIST:" + token);
+            if (blacklistedToken != null) {
+                log.debug("Blacklisted JWT token found, uri: {}", request.getRequestURI());
+            } else if (jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Set Authentication to security context for '{}', uri: {}",
+                        authentication.getName(), request.getRequestURI());
+            } else {
+                log.debug("Invalid JWT token, uri: {}", request.getRequestURI());
+            }
         } else {
-            log.debug("No valid JWT token found, uri: {}", request.getRequestURI());
+            log.debug("No JWT token found, uri: {}", request.getRequestURI());
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.sonsminpark.auratalkback.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Set Authentication to security context for '{}', uri: {}",
+                    authentication.getName(), request.getRequestURI());
+        } else {
+            log.debug("No valid JWT token found, uri: {}", request.getRequestURI());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.sonsminpark.auratalkback.global.jwt;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret:defaultSecretKey}")
+    private String secretKey;
+
+    @Value("${jwt.token-validity-in-milliseconds:86400000}") // 24시간
+    private long tokenValidityInMilliseconds;
+
+    private final UserDetailsService userDetailsService;
+    private SecretKey key;
+
+    public JwtTokenProvider(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Base64.getEncoder().encode(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(String email) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(key)
+                .compact();
+    }
+
+    public String getEmailFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getEmailFromToken(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtTokenProvider.java
@@ -1,7 +1,5 @@
 package com.sonsminpark.auratalkback.global.jwt;
 
-import com.sonsminpark.auratalkback.global.security.TokenBlacklistService;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -30,12 +28,10 @@ public class JwtTokenProvider {
     private long tokenValidityInMilliseconds;
 
     private final UserDetailsService userDetailsService;
-    private final TokenBlacklistService tokenBlacklistService;
     private SecretKey key;
 
-    public JwtTokenProvider(UserDetailsService userDetailsService, TokenBlacklistService tokenBlacklistService) {
+    public JwtTokenProvider(UserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;
-        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     @PostConstruct
@@ -67,13 +63,6 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            // 토큰이 블랙리스트에 있는지 확인
-            if (tokenBlacklistService.isBlacklisted(token)) {
-                log.error("Token is blacklisted: {}", token);
-                return false;
-            }
-
-            // 토큰 유효성 검증
             Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
@@ -87,31 +76,7 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    /**
-     * 토큰의 남은 유효 시간을 계산합니다.
-     *
-     * @param token JWT 토큰
-     * @return 남은 유효 시간(밀리초)
-     */
-    public long getTokenExpirationTime(String token) {
-        Claims claims = Jwts.parser()
-                .verifyWith(key)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
-
-        Date expiration = claims.getExpiration();
-        Date now = new Date();
-        return Math.max(0, expiration.getTime() - now.getTime());
-    }
-
-    /**
-     * 토큰을 블랙리스트에 추가합니다.
-     *
-     * @param token 블랙리스트에 추가할 JWT 토큰
-     */
-    public void blacklistToken(String token) {
-        long remainingTime = getTokenExpirationTime(token);
-        tokenBlacklistService.addToBlacklist(token, remainingTime);
+    public long getTokenValidityInMilliseconds() {
+        return tokenValidityInMilliseconds;
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/TokenBlacklistService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/TokenBlacklistService.java
@@ -1,0 +1,37 @@
+package com.sonsminpark.auratalkback.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String BLACKLIST_PREFIX = "token:blacklist:";
+
+    /**
+     * 토큰을 블랙리스트에 추가합니다.
+     *
+     * @param token 블랙리스트에 추가할 JWT 토큰
+     * @param expirationTime 토큰 만료까지 남은 시간(밀리초)
+     */
+    public void addToBlacklist(String token, long expirationTime) {
+        String key = BLACKLIST_PREFIX + token;
+        redisTemplate.opsForValue().set(key, "blacklisted", expirationTime, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인합니다.
+     *
+     * @param token 확인할 JWT 토큰
+     * @return 블랙리스트에 있으면 true, 아니면 false
+     */
+    public boolean isBlacklisted(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/security/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package com.sonsminpark.auratalkback.global.security;
+
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmailAndIsDeletedFalse(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일이 존재하지 않거나 탈퇴한 사용자입니다: " + email));
+    }
+
+    private UserDetails createUserDetails(User user) {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singletonList(authority)
+        );
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/security/TokenBlacklistService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/security/TokenBlacklistService.java
@@ -11,12 +11,12 @@ import java.util.concurrent.TimeUnit;
 public class TokenBlacklistService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String BLACKLIST_PREFIX = "token:blacklist:";
+    private static final String BLACKLIST_PREFIX = "BLACKLIST:";
 
     /**
      * 토큰을 블랙리스트에 추가합니다.
      *
-     * @param token 블랙리스트에 추가할 JWT 토큰
+     * @param token          블랙리스트에 추가할 JWT 토큰
      * @param expirationTime 토큰 만료까지 남은 시간(밀리초)
      */
     public void addToBlacklist(String token, long expirationTime) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,30 @@
 spring:
   application:
     name: aura-talk-back
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: ${SHOW_SQL:true}
+        dialect: org.hibernate.dialect.MySQL8Dialect
+  session:
+    store-type: none
+
+  data:
+    redis:
+      port: ${REDIS_PORT:6379}
+      host: ${REDIS_HOST:localhost}
+      password: ${REDIS_PASSWORD:}
+jwt:
+  secret: ${JWT_SECRET}
+  token-validity-in-milliseconds: ${JWT_EXPIRATION:86400000}
+
+server:
+  port: ${SERVER_PORT:8080}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,29 +2,30 @@ spring:
   application:
     name: aura-talk-back
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME:root}
+    url: ${DB_LOCAL_URL}
+    username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:update}
+      ddl-auto: ${JPA_DDL_AUTO}
     properties:
       hibernate:
         format_sql: true
-        show_sql: ${SHOW_SQL:true}
+        show_sql: ${SHOW_SQL}
         dialect: org.hibernate.dialect.MySQL8Dialect
   session:
     store-type: none
 
   data:
     redis:
-      port: ${REDIS_PORT:6379}
-      host: ${REDIS_HOST:localhost}
-      password: ${REDIS_PASSWORD:}
+      port: ${REDIS_PORT}
+      host: ${REDIS_LOCAL_HOST}
+      password: ${REDIS_PASSWORD}
+
 jwt:
   secret: ${JWT_SECRET}
-  token-validity-in-milliseconds: ${JWT_EXPIRATION:86400000}
+  token-validity-in-milliseconds: ${JWT_EXPIRATION}
 
 server:
-  port: ${SERVER_PORT:8080}
+  port: ${SERVER_PORT}


### PR DESCRIPTION
## 작업 내용
- 사용자 인증 관련 로그인 및 로그아웃 기능 구현
- JWT 토큰 발급 및 검증 로직 구현
- Redis를 활용한 토큰 블랙리스트 관리 시스템 구현
- 로그인/로그아웃 시 사용자 상태(ONLINE/OFFLINE)를 자동으로 변경하도록 구현
- 비밀번호 암호화 및 검증 로직 구현
- Swagger 문서 설정

## 연관된 이슈
- #1

## 스크린샷
- .env 환경 변수 설정이 잘 되지 않는 문제를 수동으로 설정하여 해결했습니다.

![image](https://github.com/user-attachments/assets/9df388e0-d430-4068-8f77-cb55f14a3d67)

## 특이사항
- Q1. 사용자의 랜덤채팅 ON/OFF를 위한 필드를 User 엔티티에 추가해야 할 것 같습니다. 어떻게 생각하시나요? → ✅ ERD 추가
- Q2. 현재는 AccessToken만 구현했는데, JWT 토큰의 탈취 위험을 최소화하기 위해서 RefreshToken 구현하는 게 좋을까요?
- JWT 토큰 유효기간을 24시간으로 설정했습니다.