### PR TITLE
[BE] 사용자 이메일 인증 비활성화 및 예외 처리 통일

### DIFF
--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserCredentialsException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserCredentialsException.java
@@ -7,11 +7,19 @@ import com.sonsminpark.auratalkback.global.exception.ErrorCode;
  * 사용자 인증 정보가 잘못되었을 때 발생하는 예외
  */
 public class InvalidUserCredentialsException extends BusinessException {
-    public InvalidUserCredentialsException() {
+    private InvalidUserCredentialsException() {
         super(ErrorCode.INVALID_CREDENTIALS);
     }
 
-    public InvalidUserCredentialsException(String message) {
+    private InvalidUserCredentialsException(String message) {
         super(ErrorCode.INVALID_CREDENTIALS, message);
+    }
+
+    public static InvalidUserCredentialsException of() {
+        return new InvalidUserCredentialsException();
+    }
+
+    public static InvalidUserCredentialsException of(String message) {
+        return new InvalidUserCredentialsException(message);
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserInputException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/InvalidUserInputException.java
@@ -7,11 +7,19 @@ import com.sonsminpark.auratalkback.global.exception.ErrorCode;
  * 사용자 관련 입력값 오류가 발생했을 때 발생하는 예외
  */
 public class InvalidUserInputException extends BusinessException {
-    public InvalidUserInputException() {
+    private InvalidUserInputException() {
         super(ErrorCode.INVALID_INPUT_VALUE);
     }
 
-    public InvalidUserInputException(String message) {
+    private InvalidUserInputException(String message) {
         super(ErrorCode.INVALID_INPUT_VALUE, message);
+    }
+
+    public static InvalidUserInputException of() {
+        return new InvalidUserInputException();
+    }
+
+    public static InvalidUserInputException of(String message) {
+        return new InvalidUserInputException(message);
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/UserNotFoundException.java
@@ -7,19 +7,27 @@ import com.sonsminpark.auratalkback.global.exception.ErrorCode;
  * 사용자를 찾을 수 없을 때 발생하는 예외
  */
 public class UserNotFoundException extends BusinessException {
-    public UserNotFoundException() {
+    private UserNotFoundException() {
         super(ErrorCode.USER_NOT_FOUND);
     }
 
-    public UserNotFoundException(String message) {
+    private UserNotFoundException(String message) {
         super(ErrorCode.USER_NOT_FOUND, message);
     }
 
-    public UserNotFoundException(Long userId) {
-        super(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다. ID: " + userId);
+    public static UserNotFoundException of() {
+        return new UserNotFoundException();
     }
 
-    public UserNotFoundException(String email, String reason) {
-        super(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다. 이메일: " + email + ", 이유: " + reason);
+    public static UserNotFoundException of(String message) {
+        return new UserNotFoundException(message);
+    }
+
+    public static UserNotFoundException of(Long userId) {
+        return new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId);
+    }
+
+    public static UserNotFoundException of(String email, String reason) {
+        return new UserNotFoundException("사용자를 찾을 수 없습니다. 이메일: " + email + ", 이유: " + reason);
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -90,12 +90,12 @@ public class UserServiceImpl implements UserService {
                 .interests(new ArrayList<>())
                 .status(UserStatus.ONLINE)
                 .isDeleted(false)
-                .emailVerified(true) // TODO: 이메일 인증 필요 시 해당 줄 제거하기
+                .emailVerified(true) // TODO: 이메일 인증 활성화 시 해당 줄 제거하기
                 .build();
 
         User savedUser = userRepository.save(user);
 
-        // TODO: 이메일 인증 필요 시 아래 주석 제거하기
+        // TODO: 이메일 인증 활성화 시 아래 주석 제거하기
 //        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());
 //        emailService.sendVerificationEmail(savedUser.getEmail(), verificationToken);
 
@@ -169,7 +169,8 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public boolean verifyEmail(EmailVerificationRequestDto emailVerificationRequestDto) {
-        if (!emailService.validateVerificationToken(
+        // TODO: 항상 성공을 반환하므로 이메일 인증 활성화 시 아래 주석 제거하기
+        /*if (!emailService.validateVerificationToken(
                 emailVerificationRequestDto.getEmail(),
                 emailVerificationRequestDto.getToken())) {
             return false;
@@ -178,7 +179,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByEmailAndIsDeletedFalse(emailVerificationRequestDto.getEmail())
                 .orElseThrow(() -> new UserNotFoundException(emailVerificationRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
 
-        user.verifyEmail();
+        user.verifyEmail();*/
 
         return true;
     }
@@ -186,7 +187,8 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void resendVerificationEmail(String email) {
-        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+        // TODO: 아무 값도 반환하지 않으므로 이메일 인증 활성화 시 아래 주석 제거하기
+        /*User user = userRepository.findByEmailAndIsDeletedFalse(email)
                 .orElseThrow(() -> new UserNotFoundException(email, "존재하지 않는 사용자입니다."));
 
         // 이미 인증된 경우
@@ -196,6 +198,6 @@ public class UserServiceImpl implements UserService {
 
         // 새 인증 토큰 생성 및 전송
         String verificationToken = emailService.generateVerificationToken(email);
-        emailService.sendVerificationEmail(email, verificationToken);
+        emailService.sendVerificationEmail(email, verificationToken);*/
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
+//import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +39,7 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new UserNotFoundException(loginRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
 
         if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
-            throw new InvalidUserCredentialsException("이메일 또는 비밀번호가 일치하지 않습니다.");
+            throw InvalidUserCredentialsException.of("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
         // 로그인 시 ONLINE으로 변경
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
 
 
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
-                .orElseThrow(() -> new UserNotFoundException(email, "존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> UserNotFoundException.of(email, "존재하지 않는 사용자입니다."));
 
         // 로그아웃 시 OFFLINE으로 변경
         user.updateStatus(UserStatus.OFFLINE);
@@ -111,15 +111,15 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void deleteUser(Long userId, UserDeleteRequestDto userDeleteRequestDto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(userId));
+                .orElseThrow(() -> UserNotFoundException.of(userId));
 
         // 이미 탈퇴한 회원인지 확인
         if (user.isDeleted()) {
-            throw new InvalidUserInputException("이미 탈퇴한 회원입니다.");
+            throw InvalidUserInputException.of("이미 탈퇴한 회원입니다.");
         }
 
         if (!passwordEncoder.matches(userDeleteRequestDto.getPassword(), user.getPassword())) {
-            throw new InvalidUserCredentialsException("비밀번호가 일치하지 않습니다.");
+            throw InvalidUserCredentialsException.of("비밀번호가 일치하지 않습니다.");
         }
 
         user.delete();
@@ -145,7 +145,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void setupProfile(Long userId, ProfileSetupRequestDto profileSetupRequestDto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(userId));
+                .orElseThrow(() -> UserNotFoundException.of(userId));
 
         // 사용자명 중복 확인
         if (userRepository.existsByUsernameAndIsDeletedFalse(profileSetupRequestDto.getUsername()) &&
@@ -177,7 +177,7 @@ public class UserServiceImpl implements UserService {
         }
 
         User user = userRepository.findByEmailAndIsDeletedFalse(emailVerificationRequestDto.getEmail())
-                .orElseThrow(() -> new UserNotFoundException(emailVerificationRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> UserNotFoundException.of(emailVerificationRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
 
         user.verifyEmail();*/
 
@@ -189,11 +189,11 @@ public class UserServiceImpl implements UserService {
     public void resendVerificationEmail(String email) {
         // TODO: 아무 값도 반환하지 않으므로 이메일 인증 활성화 시 아래 주석 제거하기
         /*User user = userRepository.findByEmailAndIsDeletedFalse(email)
-                .orElseThrow(() -> new UserNotFoundException(email, "존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> UserNotFoundException.of(email, "존재하지 않는 사용자입니다."));
 
         // 이미 인증된 경우
         if (user.isEmailVerified()) {
-            throw new InvalidUserInputException("이미 인증된 이메일입니다.");
+            throw InvalidUserInputException.of("이미 인증된 이메일입니다.");
         }
 
         // 새 인증 토큰 생성 및 전송

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -90,12 +90,14 @@ public class UserServiceImpl implements UserService {
                 .interests(new ArrayList<>())
                 .status(UserStatus.ONLINE)
                 .isDeleted(false)
+                .emailVerified(true) // TODO: 이메일 인증 필요 시 해당 줄 제거하기
                 .build();
 
         User savedUser = userRepository.save(user);
 
-        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());
-        emailService.sendVerificationEmail(savedUser.getEmail(), verificationToken);
+        // TODO: 이메일 인증 필요 시 아래 주석 제거하기
+//        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());
+//        emailService.sendVerificationEmail(savedUser.getEmail(), verificationToken);
 
         String token = jwtTokenProvider.createToken(savedUser.getEmail());
 


### PR DESCRIPTION
## 작업 내용
- 이메일 인증 프로세스 비활성화
- 예외 처리 방식을 정적 팩토리 메서드 패턴으로 통일

## 연관된 이슈
- #9

## 스크린샷
### 예외 처리 방식 변경 전/후 코드

변경 전:
```java
throw new UserNotFoundException(userId);
```

변경 후:
```java
throw UserNotFoundException.of(userId);
```

## 특이사항
- 이메일 인증/재인증 시 무조건 true값 반환
- 회원가입 → 로그인 과정에서 이메일 인증 과정 무시 가능