### PR TITLE
[BE] 프로필 조회 및 랜덤 채팅 설정 구현

### DIFF
--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.sonsminpark.auratalkback.domain.user.controller;
 import com.sonsminpark.auratalkback.domain.user.dto.request.*;
 import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
 import com.sonsminpark.auratalkback.domain.user.dto.response.SignUpResponseDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.UserResponseDto;
 import com.sonsminpark.auratalkback.domain.user.service.UserService;
 import com.sonsminpark.auratalkback.global.common.ApiResponse;
 import com.sonsminpark.auratalkback.global.exception.ErrorCode;
@@ -81,5 +82,21 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> resendVerificationEmail(@Valid @RequestBody EmailResendRequestDto requestDto) {
         userService.resendVerificationEmail(requestDto.getEmail());
         return ResponseEntity.ok(ApiResponse.success("인증 이메일이 재전송되었습니다."));
+    }
+
+    @GetMapping("/{userId}")
+    @Operation(summary = "프로필 조회", description = "사용자 프로필 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<UserResponseDto>> getUserProfile(@PathVariable Long userId) {
+        UserResponseDto userResponseDto = userService.getUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success("프로필 조회에 성공했습니다.", userResponseDto));
+    }
+
+    @PutMapping("/{userId}/chat-settings")
+    @Operation(summary = "랜덤 채팅 설정", description = "랜덤 채팅 매칭 활성화/비활성화 설정을 변경합니다.")
+    public ResponseEntity<ApiResponse<Void>> updateChatSettings(
+            @PathVariable Long userId,
+            @Valid @RequestBody ChatSettingsRequestDto chatSettingsRequestDto) {
+        userService.updateChatSettings(userId, chatSettingsRequestDto.isRandomChatEnabled());
+        return ResponseEntity.ok(ApiResponse.success("랜덤 채팅 설정이 변경되었습니다."));
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.sonsminpark.auratalkback.domain.user.service.UserService;
 import com.sonsminpark.auratalkback.global.common.ApiResponse;
 import com.sonsminpark.auratalkback.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,11 @@ public class UserController {
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃 처리합니다.")
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인된 사용자를 로그아웃 처리합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
     public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String authHeader) {
         String token = authHeader.substring(7);
         userService.logout(token);
@@ -47,7 +52,11 @@ public class UserController {
     }
 
     @DeleteMapping("/{userId}")
-    @Operation(summary = "회원탈퇴", description = "회원 탈퇴 처리를 합니다. 30일간 정보를 보관 후 삭제됩니다.")
+    @Operation(
+            summary = "회원탈퇴",
+            description = "회원 탈퇴 처리를 합니다. 30일간 정보를 보관 후 삭제됩니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
     public ResponseEntity<ApiResponse<Void>> deleteUser(
             @PathVariable Long userId,
             @Valid @RequestBody UserDeleteRequestDto userDeleteRequestDto) {
@@ -56,7 +65,11 @@ public class UserController {
     }
 
     @PutMapping("/{userId}/profile")
-    @Operation(summary = "프로필 설정", description = "회원가입 후 사용자 프로필 정보를 설정합니다.")
+    @Operation(
+            summary = "프로필 설정",
+            description = "회원가입 후 사용자 프로필 정보를 설정합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
     public ResponseEntity<ApiResponse<Void>> setupProfile(
             @PathVariable Long userId,
             @Valid @RequestBody ProfileSetupRequestDto profileSetupRequestDto) {
@@ -85,14 +98,22 @@ public class UserController {
     }
 
     @GetMapping("/{userId}")
-    @Operation(summary = "프로필 조회", description = "사용자 프로필 정보를 조회합니다.")
+    @Operation(
+            summary = "프로필 조회",
+            description = "사용자 프로필 정보를 조회합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
     public ResponseEntity<ApiResponse<UserResponseDto>> getUserProfile(@PathVariable Long userId) {
         UserResponseDto userResponseDto = userService.getUserProfile(userId);
         return ResponseEntity.ok(ApiResponse.success("프로필 조회에 성공했습니다.", userResponseDto));
     }
 
     @PutMapping("/{userId}/chat-settings")
-    @Operation(summary = "랜덤 채팅 설정", description = "랜덤 채팅 매칭 활성화/비활성화 설정을 변경합니다.")
+    @Operation(
+            summary = "랜덤 채팅 설정",
+            description = "랜덤 채팅 매칭 활성화/비활성화 설정을 변경합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
     public ResponseEntity<ApiResponse<Void>> updateChatSettings(
             @PathVariable Long userId,
             @Valid @RequestBody ChatSettingsRequestDto chatSettingsRequestDto) {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/ChatSettingsRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/ChatSettingsRequestDto.java
@@ -1,0 +1,16 @@
+package com.sonsminpark.auratalkback.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatSettingsRequestDto {
+    @NotNull(message = "랜덤 채팅 활성화 여부는 필수 입력값입니다.")
+    private boolean randomChatEnabled;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/ProfileSetupRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/request/ProfileSetupRequestDto.java
@@ -25,5 +25,8 @@ public class ProfileSetupRequestDto {
     @Pattern(regexp = "^[^\\s]+$", message = "닉네임에 공백을 포함할 수 없습니다.")
     private String nickname;
 
+    @Size(max = 100, message = "한 줄 소개는 100자 이하이어야 합니다.")
+    private String description;
+
     private List<String> interests;
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
@@ -22,6 +22,7 @@ public class UserResponseDto {
     private String nickname;
     private List<String> interests;
     private UserStatus status;
+    private boolean randomChatEnabled;
     private LocalDateTime createdAt;
 
     public static UserResponseDto from(User user) {
@@ -32,6 +33,7 @@ public class UserResponseDto {
                 .nickname(user.getNickname())
                 .interests(user.getInterests())
                 .status(user.getStatus())
+                .randomChatEnabled(user.isRandomChatEnabled())
                 .createdAt(user.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/UserResponseDto.java
@@ -20,6 +20,7 @@ public class UserResponseDto {
     private String email;
     private String username;
     private String nickname;
+    private String description;
     private List<String> interests;
     private UserStatus status;
     private boolean randomChatEnabled;
@@ -31,6 +32,7 @@ public class UserResponseDto {
                 .email(user.getEmail())
                 .username(user.getUsername())
                 .nickname(user.getNickname())
+                .description(user.getDescription())
                 .interests(user.getInterests())
                 .status(user.getStatus())
                 .randomChatEnabled(user.isRandomChatEnabled())

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
@@ -52,6 +52,9 @@ public class User {
     @Column(nullable = false)
     private boolean emailVerified = false;
 
+    @Column(nullable = false)
+    private boolean randomChatEnabled = false;
+
     public void updateStatus(UserStatus status) {
         this.status = status;
     }
@@ -71,6 +74,10 @@ public class User {
         this.username = username;
         this.nickname = nickname;
         this.interests = interests;
+    }
+
+    public void updateChatSettings(boolean randomChatEnabled) {
+        this.randomChatEnabled = randomChatEnabled;
     }
 
     public void verifyEmail() {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
@@ -32,6 +32,9 @@ public class User {
     @Column(nullable = false, length = 15)
     private String nickname;
 
+    @Column(length = 100)
+    private String description;
+
     @ElementCollection
     @CollectionTable(name = "user_interests", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "interest")
@@ -70,10 +73,11 @@ public class User {
         this.interests = interests;
     }
 
-    public void updateProfile(String username, String nickname, List<String> interests) {
+    public void updateProfile(String username, String nickname, List<String> interests, String description) {
         this.username = username;
         this.nickname = nickname;
         this.interests = interests;
+        this.description = description;
     }
 
     public void updateChatSettings(boolean randomChatEnabled) {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.sonsminpark.auratalkback.domain.user.service;
 import com.sonsminpark.auratalkback.domain.user.dto.request.*;
 import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
 import com.sonsminpark.auratalkback.domain.user.dto.response.SignUpResponseDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.UserResponseDto;
 
 public interface UserService {
     // 로그인
@@ -25,4 +26,10 @@ public interface UserService {
 
     // 이메일 인증 메일 재전송
     void resendVerificationEmail(String email);
+
+    // 프로필 조회
+    UserResponseDto getUserProfile(Long userId);
+
+    // 랜덤 채팅 설정 업데이트
+    void updateChatSettings(Long userId, boolean randomChatEnabled);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -36,7 +36,7 @@ public class UserServiceImpl implements UserService {
     public LoginResponseDto login(LoginRequestDto loginRequestDto) {
 
         User user = userRepository.findByEmailAndIsDeletedFalse(loginRequestDto.getEmail())
-                .orElseThrow(() -> new UserNotFoundException(loginRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> UserNotFoundException.of(loginRequestDto.getEmail(), "존재하지 않는 사용자입니다."));
 
         if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
             throw InvalidUserCredentialsException.of("이메일 또는 비밀번호가 일치하지 않습니다.");

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -162,7 +162,8 @@ public class UserServiceImpl implements UserService {
         user.updateProfile(
                 profileSetupRequestDto.getUsername(),
                 profileSetupRequestDto.getNickname(),
-                profileSetupRequestDto.getInterests()
+                profileSetupRequestDto.getInterests(),
+                profileSetupRequestDto.getDescription()
         );
     }
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -200,4 +200,30 @@ public class UserServiceImpl implements UserService {
         String verificationToken = emailService.generateVerificationToken(email);
         emailService.sendVerificationEmail(email, verificationToken);*/
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponseDto getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        if (user.isDeleted()) {
+            throw InvalidUserInputException.of("탈퇴한 회원의 프로필은 조회할 수 없습니다.");
+        }
+
+        return UserResponseDto.from(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateChatSettings(Long userId, boolean randomChatEnabled) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        if (user.isDeleted()) {
+            throw InvalidUserInputException.of("탈퇴한 회원은 설정을 변경할 수 없습니다.");
+        }
+
+        user.updateChatSettings(randomChatEnabled);
+    }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.sonsminpark.auratalkback.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // JWT 인증 정보 추가
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        Contact contact = new Contact()
+                .name("손씨네 민박집");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityRequirement)
+                .info(new Info()
+                        .title("AuraTalk API")
+                        .description("AuraTalk 백엔드 API 문서")
+                        .contact(contact)
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.sonsminpark.auratalkback.global.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
 import com.sonsminpark.auratalkback.global.security.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -7,7 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -21,25 +24,45 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenBlacklistService tokenBlacklistService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
+        // 특정 경로는 인증 체크를 건너뛰도록 설정
+        if (shouldSkipAuthentication(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveToken(request);
 
-        if (StringUtils.hasText(token)) {
-            if (tokenBlacklistService.isBlacklisted(token)) {
-                log.debug("Blacklisted JWT token found, uri: {}", request.getRequestURI());
-            } else if (jwtTokenProvider.validateToken(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("Set Authentication to security context for '{}', uri: {}",
-                        authentication.getName(), request.getRequestURI());
-            } else {
-                log.debug("Invalid JWT token, uri: {}", request.getRequestURI());
+        try {
+            if (StringUtils.hasText(token)) {
+                if (tokenBlacklistService.isBlacklisted(token)) {
+                    log.debug("Blacklisted JWT token found, uri: {}", request.getRequestURI());
+                    sendErrorResponse(response, ErrorCode.INVALID_AUTH_TOKEN, "로그아웃된 토큰입니다.");
+                    return;
+                } else if (jwtTokenProvider.validateToken(token)) {
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("Set Authentication to security context for '{}', uri: {}",
+                            authentication.getName(), request.getRequestURI());
+                } else {
+                    log.debug("Invalid JWT token, uri: {}", request.getRequestURI());
+                    sendErrorResponse(response, ErrorCode.INVALID_AUTH_TOKEN, "유효하지 않은 토큰입니다.");
+                    return;
+                }
+            } else if (!shouldBypassMissingTokenCheck(request)) {
+                log.debug("No JWT token found, uri: {}", request.getRequestURI());
+                sendErrorResponse(response, ErrorCode.UNAUTHORIZED, "인증 토큰이 필요합니다.");
+                return;
             }
-        } else {
-            log.debug("No JWT token found, uri: {}", request.getRequestURI());
+        } catch (Exception e) {
+            log.error("Authentication error: {}", e.getMessage());
+            sendErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR, "인증 처리 중 오류가 발생했습니다.");
+            return;
         }
 
         filterChain.doFilter(request, response);
@@ -51,5 +74,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> apiResponse = ApiResponse.error(errorCode, message);
+
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+        response.getWriter().write(jsonResponse);
+    }
+
+    private boolean shouldSkipAuthentication(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        return path.startsWith("/swagger-ui") ||
+                path.startsWith("/v3/api-docs") ||
+                path.startsWith("/swagger-resources") ||
+                path.startsWith("/webjars") ||
+                path.equals("/api/users/login") ||
+                (path.equals("/api/users") && "POST".equalsIgnoreCase(method)) ||
+                path.startsWith("/api/users/verify-email") ||
+                path.startsWith("/api/users/resend-verification");
+    }
+
+    private boolean shouldBypassMissingTokenCheck(HttpServletRequest request) {
+        // 인증이 필요하지만 토큰이 없어도 되는 경우
+        return "OPTIONS".equalsIgnoreCase(request.getMethod());
     }
 }


### PR DESCRIPTION
## 작업 내용
- 프로필 조회 및 랜덤 채팅 ON/OFF 설정 기능을 구현했습니다.
- Swagger UI에서 발생하던 403 오류를 해결하기 위해 인증 관련 설정을 개선했습니다.
- JWT 토큰을 Swagger UI에서 입력할 수 있는 기능을 추가하여 API 테스트가 가능하도록 구현했습니다.

## 연관된 이슈
- #7
- #8

## 스크린샷
없음

## 특이사항
- 프로필 수정 및 프로필 조회 필드에서 '한 줄 소개' 필드 추가 예정입니다.