### PR TITLE
[BE] Spring Security CORS 설정 비활성화

### DIFF
--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -16,11 +16,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .cors(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests ->
@@ -51,20 +51,6 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        // TODO: 운영 환경에서 CORS 설정 변경하기
-        configuration.setAllowedOrigins(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));
-        configuration.setExposedHeaders(Arrays.asList("Authorization"));
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 
     @Bean


### PR DESCRIPTION
### 작업 내용
- CORS 관련 헤더가 중복 발행되는 문제 해결했습니다.
- Spring Security에서 CORS 설정을 비활성화하여 nginx에서만 CORS 처리하도록 수정했습니다.
- `.cors(cors -> cors.configurationSource(corsConfigurationSource()))`에서 `.cors(AbstractHttpConfigurer::disable)`로 변경
- 불필요한 `corsConfigurationSource()` 메서드와 관련 import 제거했습니다

### 연관된 이슈
- #14

### 스크린샷
없음

### 특이사항
- 에러 수정 전: 브라우저 콘솔에서 아래와 같은 CORS 오류 발생
```
Access to XMLHttpRequest at 'https://api.auratalk.kro.kr/api/users/login' from origin 'http://localhost:3000' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.
```
- CORS 문제가 해결되었는지 프론트엔드 환경에서 테스트 필요합니다.