### PR TITLE
[BE] 관심사 조회 구현

### DIFF
--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/config/InterestConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/config/InterestConfig.java
@@ -1,0 +1,9 @@
+package com.sonsminpark.auratalkback.domain.interest.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "com.sonsminpark.auratalkback.domain.interest")
+public class InterestConfig {
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/controller/InterestController.java
@@ -1,0 +1,49 @@
+package com.sonsminpark.auratalkback.domain.interest.controller;
+
+import com.sonsminpark.auratalkback.domain.interest.dto.InterestCategoryDto;
+import com.sonsminpark.auratalkback.domain.interest.dto.response.InterestUsersResponseDto;
+import com.sonsminpark.auratalkback.domain.interest.dto.response.InterestResponseDto;
+import com.sonsminpark.auratalkback.domain.interest.service.InterestService;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/interests")
+@RequiredArgsConstructor
+@Tag(name = "Interest", description = "관심사 관련 API")
+public class InterestController {
+
+    private final InterestService interestService;
+
+    @GetMapping
+    @Operation(summary = "전체 관심사 조회", description = "카테고리별로 모든 관심사를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<InterestCategoryDto>>> getAllInterests() {
+        List<InterestCategoryDto> interests = interestService.getAllInterestsByCategory();
+        return ResponseEntity.ok(ApiResponse.success("관심사 조회에 성공했습니다.", interests));
+    }
+
+    @GetMapping("/category/{category}")
+    @Operation(summary = "카테고리별 관심사 조회", description = "특정 카테고리의 관심사를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<InterestResponseDto>>> getInterestsByCategory(
+            @PathVariable String category) {
+        List<InterestResponseDto> interests = interestService.getInterestsByCategory(category);
+        return ResponseEntity.ok(ApiResponse.success("카테고리별 관심사 조회에 성공했습니다.", interests));
+    }
+
+    @GetMapping("/{interestName}/users")
+    @Operation(summary = "관심사별 사용자 조회", description = "특정 관심사를 가진 사용자들을 조회합니다.")
+    public ResponseEntity<ApiResponse<InterestUsersResponseDto>> getUsersByInterest(
+            @PathVariable String interestName) {
+        InterestUsersResponseDto response = interestService.getUsersByInterestName(interestName);
+        return ResponseEntity.ok(ApiResponse.success("관심사별 사용자 조회에 성공했습니다.", response));
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/InterestCategoryDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/InterestCategoryDto.java
@@ -1,0 +1,18 @@
+package com.sonsminpark.auratalkback.domain.interest.dto;
+
+import com.sonsminpark.auratalkback.domain.interest.dto.response.InterestResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterestCategoryDto {
+    private String category;
+    private List<InterestResponseDto> interests;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestResponseDto.java
@@ -1,0 +1,34 @@
+package com.sonsminpark.auratalkback.domain.interest.dto.response;
+
+import com.sonsminpark.auratalkback.domain.interest.entity.Interest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterestResponseDto {
+    private Long id;
+    private String name;
+    private String category;
+
+    public static InterestResponseDto from(Interest interest) {
+        return InterestResponseDto.builder()
+                .id(interest.getId())
+                .name(interest.getName())
+                .category(interest.getCategory())
+                .build();
+    }
+
+    public static List<InterestResponseDto> fromList(List<Interest> interests) {
+        return interests.stream()
+                .map(InterestResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestUsersResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestUsersResponseDto.java
@@ -1,0 +1,18 @@
+package com.sonsminpark.auratalkback.domain.interest.dto.response;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.UserResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterestUsersResponseDto {
+    private String interestName;
+    private List<UserResponseDto> users;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/entity/Interest.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/entity/Interest.java
@@ -1,0 +1,51 @@
+package com.sonsminpark.auratalkback.domain.interest.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "interests")
+public class Interest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private String category;
+
+    // 자동 저장을 위한 정적 메서드
+    public static List<Interest> createDefaultInterests() {
+        List<Interest> interests = new ArrayList<>();
+
+        // 취미
+        interests.add(Interest.builder().name("게임").category("취미").build());
+        interests.add(Interest.builder().name("요리").category("취미").build());
+        interests.add(Interest.builder().name("댄스").category("취미").build());
+        interests.add(Interest.builder().name("웹서핑").category("취미").build());
+        interests.add(Interest.builder().name("프로그래밍").category("취미").build());
+
+        // 자기개발
+        interests.add(Interest.builder().name("독서").category("자기개발").build());
+        interests.add(Interest.builder().name("운동").category("자기개발").build());
+        interests.add(Interest.builder().name("미라클모닝").category("자기개발").build());
+        interests.add(Interest.builder().name("공부").category("자기개발").build());
+
+        // 일상
+        interests.add(Interest.builder().name("코디").category("일상").build());
+        interests.add(Interest.builder().name("메뉴 추천").category("일상").build());
+        interests.add(Interest.builder().name("챌린지").category("일상").build());
+
+        return interests;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/repository/InterestRepository.java
@@ -1,0 +1,20 @@
+package com.sonsminpark.auratalkback.domain.interest.repository;
+
+import com.sonsminpark.auratalkback.domain.interest.entity.Interest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+
+    Optional<Interest> findByName(String name);
+
+    List<Interest> findByCategory(String category);
+
+    @Query("SELECT DISTINCT i.category FROM Interest i ORDER BY i.category")
+    List<String> findAllCategories();
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/service/InterestService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/service/InterestService.java
@@ -1,0 +1,79 @@
+package com.sonsminpark.auratalkback.domain.interest.service;
+
+import com.sonsminpark.auratalkback.domain.interest.dto.InterestCategoryDto;
+import com.sonsminpark.auratalkback.domain.interest.dto.response.InterestResponseDto;
+import com.sonsminpark.auratalkback.domain.interest.dto.response.InterestUsersResponseDto;
+import com.sonsminpark.auratalkback.domain.interest.entity.Interest;
+import com.sonsminpark.auratalkback.domain.interest.repository.InterestRepository;
+import com.sonsminpark.auratalkback.domain.user.dto.response.UserResponseDto;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterestService {
+
+    private final InterestRepository interestRepository;
+    private final UserRepository userRepository;
+
+    // 애플리케이션 시작 시 기본 관심사 초기화
+    @PostConstruct
+    @Transactional
+    public void initInterests() {
+        if (interestRepository.count() == 0) {
+            log.info("기본 관심사 데이터 초기화 중...");
+            List<Interest> defaultInterests = Interest.createDefaultInterests();
+            interestRepository.saveAll(defaultInterests);
+            log.info("기본 관심사 데이터 {} 개 초기화 완료", defaultInterests.size());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<InterestCategoryDto> getAllInterestsByCategory() {
+        List<String> categories = interestRepository.findAllCategories();
+
+        return categories.stream()
+                .map(category -> {
+                    List<Interest> interests = interestRepository.findByCategory(category);
+                    return InterestCategoryDto.builder()
+                            .category(category)
+                            .interests(InterestResponseDto.fromList(interests))
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public InterestUsersResponseDto getUsersByInterestName(String interestName) {
+        Interest interest = interestRepository.findByName(interestName)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 관심사입니다: " + interestName));
+
+        List<User> users = userRepository.findAll().stream()
+                .filter(user -> !user.isDeleted() && user.getInterests().contains(interestName))
+                .collect(Collectors.toList());
+
+        List<UserResponseDto> userDtos = users.stream()
+                .map(UserResponseDto::from)
+                .collect(Collectors.toList());
+
+        return InterestUsersResponseDto.builder()
+                .interestName(interestName)
+                .users(userDtos)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<InterestResponseDto> getInterestsByCategory(String category) {
+        List<Interest> interests = interestRepository.findByCategory(category);
+        return InterestResponseDto.fromList(interests);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/SecurityConfig.java
@@ -40,6 +40,9 @@ public class SecurityConfig {
                                 // 인증 없이 접근 가능
                                 .requestMatchers("/api/users/login", "/api/users",
                                         "/api/users/verify-email", "/api/users/resend-verification").permitAll()
+                                // 관심사 API 접근 설정
+                                .requestMatchers("/api/interests", "/api/interests/category/**").permitAll()
+                                .requestMatchers("/api/interests/*/users").authenticated()
                                 // TODO: 인증 설정 필요하면 추가하기
                                 .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistService),


### PR DESCRIPTION
## 작업 내용
- 관심사 조회 API 구현
- 관심사별 사용자 조회 API 구현

## 연관된 이슈
- #16

## 스크린샷 (선택)
없음

## 특이사항(선택)
- 관심사에는 카테고리 정보가 중첩되어 있습니다. 검색/필터링을 위해 이렇게 설계했습니다.
- 애플리케이션 시작 시 관심사 데이터가 자동으로 초기화됩니다. 중복 저장이 안 되게 해놨습니다.