### PR TITLE
[BE] 사용자 프로필 업로드/조회 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,9 @@ jobs:
           server.port: ${{ secrets.SERVER_PORT }}
           swagger.servers.prodHttps: ${{ secrets.HTTPS_URL }}
           swagger.servers.prodHttp: ${{ secrets.HTTP_URL }}
+          cloud.aws.credentials.access-key: ${{ secrets.S3_ACCESS_KEY }}
+          cloud.aws.credentials.secret-key: ${{ secrets.S3_SECRET_KEY }}
+          cloud.aws.s3.bucket: ${{ secrets.S3_BUCKET_NAME }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    implementation 'software.amazon.awssdk:s3:2.31.21'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserController.java
@@ -130,7 +130,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("랜덤 채팅 설정이 변경되었습니다."));
     }
 
-    @PostMapping("/profile-image")
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "프로필 이미지 업로드",
             description = "사용자의 프로필 이미지를 업로드합니다.",

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/ProfileImageResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/ProfileImageResponseDto.java
@@ -1,0 +1,15 @@
+package com.sonsminpark.auratalkback.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileImageResponseDto {
+    private Long userId;
+    private String imageUrl;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserProfileImage.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserProfileImage.java
@@ -1,0 +1,30 @@
+package com.sonsminpark.auratalkback.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user_profile_images")
+public class UserProfileImage {
+
+    @Id
+    private Long userId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 1000)
+    private String imageUrl;
+
+
+    public void updateProfileImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/ImageSizeLimitExceededException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/ImageSizeLimitExceededException.java
@@ -1,0 +1,13 @@
+package com.sonsminpark.auratalkback.domain.user.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+public class ImageSizeLimitExceededException extends BusinessException {
+    public ImageSizeLimitExceededException(String message) {
+        super(ErrorCode.FILE_UPLOAD_ERROR, message);
+    }
+    public static ImageSizeLimitExceededException of(String message) {
+        return new ImageSizeLimitExceededException(message);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/ProfileImageNotFoundException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/exception/ProfileImageNotFoundException.java
@@ -1,0 +1,16 @@
+package com.sonsminpark.auratalkback.domain.user.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+public class ProfileImageNotFoundException extends BusinessException {
+
+    public ProfileImageNotFoundException(String message) {
+        super(ErrorCode.ENTITY_NOT_FOUND, message);
+    }
+
+    public static ProfileImageNotFoundException of(String message) {
+        return new ProfileImageNotFoundException(message);
+    }
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserProfileImageRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserProfileImageRepository.java
@@ -1,0 +1,12 @@
+package com.sonsminpark.auratalkback.domain.user.repository;
+
+import com.sonsminpark.auratalkback.domain.user.entity.UserProfileImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProfileImageRepository  extends JpaRepository<UserProfileImage, Long> {
+    Optional<UserProfileImage> findByUserId(Long userId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/ProfileImageService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/ProfileImageService.java
@@ -1,0 +1,13 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface ProfileImageService{
+
+    ProfileImageResponseDto uploadProfileImage(Long userId, MultipartFile file) throws IOException;
+
+    ProfileImageResponseDto getProfileImageUrl(Long userId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/ProfileImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/ProfileImageServiceImpl.java
@@ -1,0 +1,101 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageResponseDto;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.entity.UserProfileImage;
+import com.sonsminpark.auratalkback.domain.user.exception.ImageSizeLimitExceededException;
+import com.sonsminpark.auratalkback.domain.user.exception.ProfileImageNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.repository.UserProfileImageRepository;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class ProfileImageServiceImpl implements ProfileImageService {
+
+    private final S3Client s3Client;
+    private final UserProfileImageRepository userProfileImageRepository;
+    private final UserRepository userRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    @Transactional
+    public ProfileImageResponseDto uploadProfileImage(Long userId, MultipartFile file) throws IOException {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
+            throw ImageSizeLimitExceededException.of("이미지 크기가 너무 큽니다. 10MB 이하 이미지만 업로드할 수 있습니다.");
+        }
+
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key("profile-images/original/" + fileName)
+                .acl(ObjectCannedACL.PUBLIC_READ)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+        );
+
+        String profileImageUrl = "https://" + bucketName + ".s3.amazonaws.com/profile-images/original/" + fileName;
+
+        Optional<UserProfileImage> userProfileImageOptional = userProfileImageRepository.findById(userId);
+
+        if (userProfileImageOptional.isPresent()) {
+            UserProfileImage existingImage = userProfileImageOptional.get();
+            existingImage.updateProfileImage(profileImageUrl);
+        }
+        else {
+            UserProfileImage newProfileImage = UserProfileImage.builder()
+                    .user(user)
+                    .imageUrl(profileImageUrl)
+                    .build();
+            userProfileImageRepository.save(newProfileImage);
+        }
+
+        ProfileImageResponseDto profileImageResponseDto = ProfileImageResponseDto.builder()
+                .userId(userId)
+                .imageUrl(profileImageUrl)
+                .build();
+
+        return profileImageResponseDto;
+    }
+
+    @Override
+    public ProfileImageResponseDto getProfileImageUrl(Long userId) {
+        UserProfileImage profileImage = userProfileImageRepository.findByUserId(userId)
+                .orElseThrow(() -> ProfileImageNotFoundException.of("사용자 ID: " + userId + "의 프로필 이미지를 찾을 수 없습니다."));
+
+        String profileImageUrl = profileImage.getImageUrl();
+
+        ProfileImageResponseDto profileImageResponseDto = ProfileImageResponseDto.builder()
+                .userId(userId)
+                .imageUrl(profileImageUrl)
+                .build();
+
+        return profileImageResponseDto;
+
+    }
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/S3Config.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.sonsminpark.auratalkback.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     redis:
       port: ${REDIS_PORT}
       host: ${REDIS_LOCAL_HOST}
-      password: ${REDIS_PASSWORD}\
+      password: ${REDIS_PASSWORD}
 
   mail:
     host: smtp.gmail.com
@@ -46,3 +46,13 @@ swagger:
   servers:
     prodHttps: ${HTTPS_URL}
     prodHttp: ${HTTP_URL}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${S3_BUCKET_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
   session:
     store-type: none
+  servlet:
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 500MB
 
   data:
     redis:


### PR DESCRIPTION
## 작업 내용
- 사용자 프로필 업로드 기능과 프로필 조회 기능을 구현했습니다.
- 클라이언트로부터 파일을 받아 서버에서 직접 S3에 업로드하는 방식으로 구현했습니다. 

## 연관된 이슈
- #22

## 스크린샷 (선택)
Swagger에 multipart/form-data 노출하려고 고생 좀 했습니다..
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/0e3e2ae9-a851-4c83-ad4b-5c341426ea1d" />


## 특이사항(선택)
> 회원 정보를 보내줄 때 프로필 이미지 url도 같이 보내줘야 할까요?