### PR TITLE
[BE] 사용자 프로필 이미지 업로드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,9 @@ jobs:
           server.port: ${{ secrets.SERVER_PORT }}
           swagger.servers.prodHttps: ${{ secrets.HTTPS_URL }}
           swagger.servers.prodHttp: ${{ secrets.HTTP_URL }}
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+          cloud.aws.credentials.access-key: ${{ secrets.S3_ACCESS_KEY }}
+          cloud.aws.credentials.secret-key: ${{ secrets.S3_SECRET_KEY }}
+          cloud.aws.s3.bucket: ${{ secrets.S3_BUCKET_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    implementation 'software.amazon.awssdk:s3:2.31.21'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserProfileImageController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/controller/UserProfileImageController.java
@@ -1,0 +1,82 @@
+package com.sonsminpark.auratalkback.domain.user.controller;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageResponseDto;
+import com.sonsminpark.auratalkback.domain.user.service.UserProfileImageService;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import com.sonsminpark.auratalkback.global.s3.dto.request.PresignedUploadRequestDto;
+import com.sonsminpark.auratalkback.global.s3.dto.response.PresignedUploadResponseDto;
+import com.sonsminpark.auratalkback.global.s3.S3Service;
+import com.sonsminpark.auratalkback.global.s3.UploadType;
+import com.sonsminpark.auratalkback.global.s3.dto.request.UploadCompletedRequestDto;
+import com.sonsminpark.auratalkback.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@Tag(name = "User Profile Image", description = "사용자 프로필 이미지 관련 API")
+@RequestMapping("/api/users")
+@RestController
+public class UserProfileImageController {
+
+    private final S3Service s3Service;
+    private final UserProfileImageService userProfileImageService;
+
+    @PostMapping("/me/profile-image/presigned-url")
+    @Operation(
+            summary = "프로필 이미지 업로드용 S3 PresignedUrl 생성",
+            description = "사용자의 프로필 이미지 업로드를 위한 S3 PresignedUrl을 생성합니다. 클라이언트는 이 URL로 직접 S3에 파일을 업로드할 수 있습니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<PresignedUploadResponseDto>> getProfileUploadUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody PresignedUploadRequestDto presignedUploadRequestDto) {
+        PresignedUploadResponseDto presignedUploadResponseDto =
+                s3Service.generatePresignedUploadUrl(UploadType.PROFILE, presignedUploadRequestDto);
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지 업로드 URL이 생성되었습니다.", presignedUploadResponseDto));
+    }
+
+    @PostMapping("/me/profile-image/upload-complete")
+    @Operation(
+            summary = "S3 프로필 이미지 업로드 완료 처리",
+            description = "S3에 프로필 이미지 업로드가 완료된 후 호출합니다. 서버에 사용자 프로필 이미지 정보를 저장합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<ProfileImageResponseDto>> saveProfileImageUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UploadCompletedRequestDto uploadCompleteRequestDto) {
+        ProfileImageResponseDto profileImageResponseDto = userProfileImageService.updateProfileImage(
+                userDetails.getUserId(), uploadCompleteRequestDto.getS3Key());
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 성공적으로 업데이트되었습니다.", profileImageResponseDto));
+    }
+
+
+    @GetMapping("/{userId}/profile-image")
+    @Operation(
+            summary = "프로필 이미지 조회",
+            description = "특정 사용자의 프로필 이미지 정보(원본/썸네일 URL)를 조회합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ResponseEntity<ApiResponse<ProfileImageResponseDto>> getProfileImage(@PathVariable Long userId) {
+        ProfileImageResponseDto profileImageResponseDto = userProfileImageService.getProfileImage(userId);
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지 조회에 성공했습니다.", profileImageResponseDto));
+    }
+
+    @DeleteMapping("/me/profile-image")
+    @Operation(
+            summary = "프로필 이미지 삭제 및 기본 이미지로 변경",
+            description = "사용자의 프로필 이미지를 삭제하고 기본 이미지로 변경합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ResponseEntity<ApiResponse<ProfileImageResponseDto>> deleteProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        ProfileImageResponseDto profileImageResponseDto = userProfileImageService.deleteProfileImage(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 성공적으로 삭제되었습니다.", profileImageResponseDto));
+    }
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/ProfileImageResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/dto/response/ProfileImageResponseDto.java
@@ -1,0 +1,28 @@
+package com.sonsminpark.auratalkback.domain.user.dto.response;
+
+import com.sonsminpark.auratalkback.domain.user.entity.UserProfileImage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileImageResponseDto {
+
+    private Long userId;
+    private String originalImageUrl;
+    private String thumbnailImageUrl;
+    private boolean isDefaultProfileImage;
+
+    public static ProfileImageResponseDto from(UserProfileImage userProfileImage) {
+        return ProfileImageResponseDto.builder()
+                .userId(userProfileImage.getUserId())
+                .originalImageUrl(userProfileImage.getOriginalImageUrl())
+                .thumbnailImageUrl(userProfileImage.getThumbnailImageUrl())
+                .isDefaultProfileImage(userProfileImage.isDefaultProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserProfileImage.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/UserProfileImage.java
@@ -1,0 +1,42 @@
+package com.sonsminpark.auratalkback.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_profile_images")
+@Entity
+public class UserProfileImage {
+
+    @Id
+    private Long userId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column
+    private String originalImageUrl;
+
+    @Column
+    private String thumbnailImageUrl;
+
+    @Column
+    private boolean isDefaultProfileImage;
+
+    public UserProfileImage(User user) {
+        this.user = user;
+        this.userId = user.getId();
+        this.isDefaultProfileImage = true;
+    }
+
+    public void updateImage(String originalImageUrl, String thumbnailImageUrl, boolean isDefaultProfileImage) {
+        this.originalImageUrl = originalImageUrl;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.isDefaultProfileImage = isDefaultProfileImage;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserProfileImageRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserProfileImageRepository.java
@@ -1,0 +1,13 @@
+package com.sonsminpark.auratalkback.domain.user.repository;
+
+import com.sonsminpark.auratalkback.domain.user.entity.UserProfileImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProfileImageRepository extends JpaRepository<UserProfileImage, Long> {
+
+    Optional<UserProfileImage> findByUserId(Long userId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
@@ -10,7 +10,10 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByEmailAndIsDeletedFalse(String email);
+
+    Optional<User> findByIdAndIsDeletedFalse(Long userId);
 
     boolean existsByEmailAndIsDeletedFalse(String email);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageService.java
@@ -4,7 +4,7 @@ import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageRespons
 
 public interface UserProfileImageService {
 
-    ProfileImageResponseDto createDefaultProfileIamge(Long userId);
+    ProfileImageResponseDto createDefaultProfileImage(Long userId);
 
     ProfileImageResponseDto getProfileImage(Long userId);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageService.java
@@ -1,0 +1,14 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageResponseDto;
+
+public interface UserProfileImageService {
+
+    ProfileImageResponseDto createDefaultProfileIamge(Long userId);
+
+    ProfileImageResponseDto getProfileImage(Long userId);
+
+    ProfileImageResponseDto updateProfileImage(Long userId, String s3Key);
+
+    ProfileImageResponseDto deleteProfileImage(Long userId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageServiceImpl.java
@@ -39,7 +39,7 @@ public class UserProfileImageServiceImpl implements UserProfileImageService {
 
     @Override
     @Transactional
-    public ProfileImageResponseDto createDefaultProfileIamge(Long userId) {
+    public ProfileImageResponseDto createDefaultProfileImage(Long userId) {
         User user = userRepository.findByIdAndIsDeletedFalse(userId)
                 .orElseThrow(() -> UserNotFoundException.of(userId));
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserProfileImageServiceImpl.java
@@ -1,0 +1,129 @@
+package com.sonsminpark.auratalkback.domain.user.service;
+
+import com.sonsminpark.auratalkback.domain.user.dto.response.ProfileImageResponseDto;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.entity.UserProfileImage;
+import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.repository.UserProfileImageRepository;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import com.sonsminpark.auratalkback.global.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@RequiredArgsConstructor
+@Service
+public class UserProfileImageServiceImpl implements UserProfileImageService {
+
+    private final S3Client s3Client;
+    private final S3Service s3Service;
+    private final UserProfileImageRepository userProfileImageRepository;
+    private final UserRepository userRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private static final int DEFAULT_IMAGE_COUNT = 4;
+    private static record DefaultProfileImage(String originalUrl, String thumbnailUrl) {}
+
+    private DefaultProfileImage getDefaultProfileImage(Long userId) {
+        int index = Math.toIntExact(userId % DEFAULT_IMAGE_COUNT) + 1;
+        String prefix = "https://" + bucketName + ".s3.amazonaws.com/profile-images/default/";
+        return new DefaultProfileImage(
+                prefix + index + ".png",
+                prefix + index + "_thumb.png"
+        );
+    }
+
+    @Override
+    @Transactional
+    public ProfileImageResponseDto createDefaultProfileIamge(Long userId) {
+        User user = userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        DefaultProfileImage defaultProfileImage = getDefaultProfileImage(userId);
+        UserProfileImage profileImage = UserProfileImage.builder()
+                .user(user)
+                .originalImageUrl(defaultProfileImage.originalUrl())
+                .thumbnailImageUrl(defaultProfileImage.thumbnailUrl())
+                .isDefaultProfileImage(true)
+                .build();
+
+        userProfileImageRepository.save(profileImage);
+
+        return ProfileImageResponseDto.from(profileImage);
+    }
+
+    @Override
+    @Transactional
+    public ProfileImageResponseDto updateProfileImage(Long userId, String s3Key) {
+
+        User user = userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        UserProfileImage profileImage = userProfileImageRepository.findByUserId(userId)
+                .orElse(new UserProfileImage(user));
+
+        if (!profileImage.isDefaultProfileImage()) {
+            s3Service.deleteFileFromS3(profileImage.getOriginalImageUrl());
+            s3Service.deleteFileFromS3(profileImage.getThumbnailImageUrl());
+        }
+
+        String originalImageUrl = "https://" + bucketName + ".s3.amazonaws.com/" + s3Key;
+        String thumbnailImageUrl = originalImageUrl.replace("/original/", "/thumbnail/");
+
+        profileImage.updateImage(originalImageUrl, thumbnailImageUrl, false);
+        userProfileImageRepository.save(profileImage);
+
+        return ProfileImageResponseDto.from(profileImage);
+
+    }
+
+    @Override
+    @Transactional
+    public ProfileImageResponseDto getProfileImage(Long userId) {
+
+        User user = userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        UserProfileImage profileImage = userProfileImageRepository.findByUserId(userId)
+                .orElseGet(() -> {
+                    DefaultProfileImage defaultImage = getDefaultProfileImage(userId);
+                    UserProfileImage newImage = new UserProfileImage(user);
+                    newImage.updateImage(defaultImage.originalUrl(), defaultImage.thumbnailUrl(), true);
+                    return userProfileImageRepository.save(newImage);
+                });
+
+        ProfileImageResponseDto profileImageResponseDto = ProfileImageResponseDto.from(profileImage);
+
+        return profileImageResponseDto;
+
+    }
+
+    @Override
+    @Transactional
+    public ProfileImageResponseDto deleteProfileImage(Long userId) {
+
+        User user = userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+
+        DefaultProfileImage defaultImage = getDefaultProfileImage(userId);
+
+        UserProfileImage profileImage = userProfileImageRepository.findByUserId(userId)
+                .orElse(new UserProfileImage(user));
+
+        if (!profileImage.isDefaultProfileImage()) {
+            s3Service.deleteFileFromS3(profileImage.getOriginalImageUrl());
+            s3Service.deleteFileFromS3(profileImage.getThumbnailImageUrl());
+        }
+
+        profileImage.updateImage(defaultImage.originalUrl(), defaultImage.thumbnailUrl(), true);
+        userProfileImageRepository.save(profileImage);
+
+        return ProfileImageResponseDto.from(profileImage);
+    }
+
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -30,6 +30,7 @@ public class UserServiceImpl implements UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenBlacklistService tokenBlacklistService;
     private final EmailService emailService;
+    private final UserProfileImageService userProfileImageService;
 
     @Override
     @Transactional
@@ -94,6 +95,8 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         User savedUser = userRepository.save(user);
+
+        userProfileImageService.createDefaultProfileIamge(savedUser.getId());
 
         // TODO: 이메일 인증 활성화 시 아래 주석 제거하기
 //        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -96,7 +96,7 @@ public class UserServiceImpl implements UserService {
 
         User savedUser = userRepository.save(user);
 
-        userProfileImageService.createDefaultProfileIamge(savedUser.getId());
+        userProfileImageService.createDefaultProfileImage(savedUser.getId());
 
         // TODO: 이메일 인증 활성화 시 아래 주석 제거하기
 //        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());

--- a/src/main/java/com/sonsminpark/auratalkback/global/config/S3Config.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/config/S3Config.java
@@ -1,0 +1,43 @@
+package com.sonsminpark.auratalkback.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/FileUtil.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/FileUtil.java
@@ -1,0 +1,53 @@
+package com.sonsminpark.auratalkback.global.s3;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FileUtil {
+
+    private static final Map<String, String> MIME_TYPE_MAP = new HashMap<>();
+
+    static {
+        MIME_TYPE_MAP.put("jpg", "image/jpeg");
+        MIME_TYPE_MAP.put("jpeg", "image/jpeg");
+        MIME_TYPE_MAP.put("png", "image/png");
+        MIME_TYPE_MAP.put("gif", "image/gif");
+        MIME_TYPE_MAP.put("webp", "image/webp");
+        MIME_TYPE_MAP.put("pdf", "application/pdf");
+        MIME_TYPE_MAP.put("txt", "text/plain");
+        MIME_TYPE_MAP.put("doc", "application/msword");
+        MIME_TYPE_MAP.put("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        MIME_TYPE_MAP.put("xls", "application/vnd.ms-excel");
+        MIME_TYPE_MAP.put("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
+
+    public static String extractExtension(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return "";
+        }
+
+        int lastDotIndex = fileName.lastIndexOf(".");
+
+        if (lastDotIndex < 0 || lastDotIndex == fileName.length() - 1) {
+            return "";
+        }
+
+        return fileName.substring(lastDotIndex + 1).toLowerCase();
+    }
+
+    public static String getMimeType(String extension) {
+        if (extension == null || extension.isEmpty()) {
+            return "text/plain";
+        }
+
+        return MIME_TYPE_MAP.getOrDefault(extension.toLowerCase(), "application/octet-stream");
+    }
+
+    public static String createS3Key(String prefix, String uuid, String extension) {
+        if (extension == null || extension.isEmpty()) {
+            return prefix + uuid;
+        }
+        return prefix + uuid + "." + extension;
+    }
+
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/S3Service.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/S3Service.java
@@ -1,0 +1,64 @@
+package com.sonsminpark.auratalkback.global.s3;
+
+import com.sonsminpark.auratalkback.global.s3.dto.request.PresignedUploadRequestDto;
+import com.sonsminpark.auratalkback.global.s3.dto.response.PresignedUploadResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+
+    public PresignedUploadResponseDto generatePresignedUploadUrl(UploadType type, PresignedUploadRequestDto requestDto) {
+        String originalFileName = requestDto.getFileName();
+        String ext = FileUtil.extractExtension(originalFileName);
+        String contentType = FileUtil.getMimeType(ext);
+
+        String uuid = UUID.randomUUID().toString();
+        String key = FileUtil.createS3Key(type.getPrefix(), uuid, ext);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(putObjectRequest)
+                .signatureDuration(Duration.ofMinutes(3))
+                .build();
+
+        URL url = s3Presigner.presignPutObject(presignRequest).url();
+        return new PresignedUploadResponseDto(url.toString(),key);
+    }
+
+    public void deleteFileFromS3(String url) {
+        String key = extractKeyFromUrl(url);
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build());
+    }
+
+    private String extractKeyFromUrl(String url) {
+        String domain = "https://" + bucketName + ".s3.amazonaws.com/";
+        return url.replace(domain, "");
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/UploadType.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/UploadType.java
@@ -1,0 +1,19 @@
+package com.sonsminpark.auratalkback.global.s3;
+
+public enum UploadType {
+
+    PROFILE("profile-images/original/"),
+    GROUP("group-images/original/"),
+    CHAT("chat-files/");
+
+    private final String prefix;
+
+    UploadType(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}
+

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/request/PresignedUploadRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/request/PresignedUploadRequestDto.java
@@ -1,0 +1,12 @@
+package com.sonsminpark.auratalkback.global.s3.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PresignedUploadRequestDto {
+    private String fileName;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/request/UploadCompletedRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/request/UploadCompletedRequestDto.java
@@ -1,0 +1,12 @@
+package com.sonsminpark.auratalkback.global.s3.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadCompletedRequestDto {
+    private String s3Key;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/response/PresignedUploadResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/global/s3/dto/response/PresignedUploadResponseDto.java
@@ -1,0 +1,13 @@
+package com.sonsminpark.auratalkback.global.s3.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PresignedUploadResponseDto {
+    private String url;
+    private String s3Key;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,14 @@ swagger:
   servers:
     prodHttps: ${HTTPS_URL}
     prodHttp: ${HTTP_URL}
+
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${S3_BUCKET_NAME}


### PR DESCRIPTION
## 작업 내용
- PresignedURL 방식으로 프로필 이미지 업로드 기능 구현
- 클라이언트에서 S3에 업로드를 완료하면 Lambda를 통해 썸네일 이미지 생성
- 회원 가입 시 기본 프로필 이미지(4장을 순환)로 설정
- 프로필 이미지 삭제 시 기존 이미지 S3에서 삭제 및 기본 프로필 이미지로 변경
- 순서도
![Ngnix (3)](https://github.com/user-attachments/assets/0989a012-f292-4240-8a21-6b74100ecf49)


## 연관된 이슈
- #22

## 스크린샷 (선택)
- S3에 이미지 업로드를 하면 Lambda가 정상 호출됐는데 TIMEOUT 오류가 났었음.
  - 시간 제한을 3초 -> 10초로 늘려 해결.

## 특이사항(선택)
> 프로필 이미지 API 엔드포인트 경로 확인 부탁드립니다. 더 좋은 방식이 있을까요?
