### PR TITLE
[BE] 채팅 관련 N+1 쿼리 문제 해결 및 채팅방 차단된 사용자 목록 조회

### DIFF
--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatFileController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatFileController.java
@@ -1,0 +1,127 @@
+package com.sonsminpark.auratalkback.domain.chat.controller;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatFileUploadRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileDownloadResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.service.ChatFileService;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import com.sonsminpark.auratalkback.global.s3.S3Service;
+import com.sonsminpark.auratalkback.global.s3.UploadType;
+import com.sonsminpark.auratalkback.global.s3.dto.request.PresignedUploadRequestDto;
+import com.sonsminpark.auratalkback.global.s3.dto.response.PresignedUploadResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+@Tag(name = "Chat File", description = "채팅 파일 전송/다운로드 관련 API")
+public class ChatFileController {
+
+    private final ChatFileService chatFileService;
+    private final S3Service s3Service;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/{chatroomId}/files/presigned-url")
+    @Operation(
+            summary = "채팅 파일 업로드용 S3 PresignedUrl 생성",
+            description = "채팅방에 파일 업로드를 위한 S3 PresignedUrl을 생성합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<PresignedUploadResponseDto>> getFileUploadUrl(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long chatroomId,
+            @Valid @RequestBody PresignedUploadRequestDto presignedUploadRequestDto) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+
+        chatFileService.validateChatRoomAccess(chatroomId, userId);
+
+        PresignedUploadResponseDto responseDto =
+                s3Service.generatePresignedUploadUrl(UploadType.CHAT, presignedUploadRequestDto);
+
+        return ResponseEntity.ok(ApiResponse.success("파일 업로드 URL이 생성되었습니다.", responseDto));
+    }
+
+    @PostMapping("/upload/{chatroomId}")
+    @Operation(
+            summary = "파일 업로드 완료 처리",
+            description = "S3에 파일 업로드가 완료된 후 호출하여 채팅 메시지로 전송합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<ChatFileResponseDto>> uploadFile(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long chatroomId,
+            @Valid @RequestBody ChatFileUploadRequestDto requestDto) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        ChatFileResponseDto responseDto = chatFileService.completeFileUpload(chatroomId, userId, requestDto);
+
+        return ResponseEntity.ok(ApiResponse.success("파일이 성공적으로 업로드되었습니다.", responseDto));
+    }
+
+    @GetMapping("/download/{fileId}")
+    @Operation(
+            summary = "파일 다운로드",
+            description = "채팅방의 파일을 다운로드합니다. 다운로드 URL을 반환합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<ChatFileDownloadResponseDto>> downloadFile(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long fileId) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        ChatFileDownloadResponseDto responseDto = chatFileService.generateDownloadUrl(fileId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success("파일 다운로드 URL이 생성되었습니다.", responseDto));
+    }
+
+    @GetMapping("/{chatroomId}/files")
+    @Operation(
+            summary = "채팅방 파일 목록 조회",
+            description = "채팅방에 업로드된 파일 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<List<ChatFileResponseDto>>> getChatRoomFiles(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long chatroomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        List<ChatFileResponseDto> files = chatFileService.getChatRoomFiles(chatroomId, userId, page, size);
+
+        return ResponseEntity.ok(ApiResponse.success("파일 목록을 성공적으로 조회했습니다.", files));
+    }
+
+    @DeleteMapping("/files/{fileId}")
+    @Operation(
+            summary = "채팅 파일 삭제",
+            description = "업로드한 파일을 삭제합니다. 파일 업로드자만 삭제할 수 있습니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteFile(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long fileId) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        chatFileService.deleteFile(fileId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success("파일이 성공적으로 삭제되었습니다."));
+    }
+
+    private Long extractUserIdFromToken(String authHeader) {
+        String token = authHeader.substring(7);
+        return jwtTokenProvider.getUserIdFromToken(token);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
@@ -5,14 +5,17 @@ import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomCreateReques
 import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomUpdateRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.request.OneToOneChatRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatInviteResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomImageResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatUserResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.service.ChatRoomImageService;
 import com.sonsminpark.auratalkback.domain.chat.service.ChatService;
 import com.sonsminpark.auratalkback.global.common.ApiResponse;
 import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
 import com.sonsminpark.auratalkback.global.s3.S3Service;
 import com.sonsminpark.auratalkback.global.s3.UploadType;
 import com.sonsminpark.auratalkback.global.s3.dto.request.PresignedUploadRequestDto;
+import com.sonsminpark.auratalkback.global.s3.dto.request.UploadCompletedRequestDto;
 import com.sonsminpark.auratalkback.global.s3.dto.response.PresignedUploadResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,13 +39,14 @@ import java.util.List;
 public class ChatRoomController {
 
     private final ChatService chatService;
+    private final ChatRoomImageService chatRoomImageService;
     private final S3Service s3Service;
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping
     @Operation(
             summary = "채팅방 만들기",
-            description = "새로운 채팅방을 생성합니다. 채팅방 이미지를 설정하려면 roomImageS3Key를 포함하세요.",
+            description = "새로운 채팅방을 생성합니다. 채팅방 이미지URL을 포함할 수 있습니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(
@@ -50,8 +54,8 @@ public class ChatRoomController {
             @Valid @RequestBody ChatRoomCreateRequestDto requestDto) {
 
         Long userId = extractUserIdFromToken(authHeader);
-        log.info("채팅방 생성 요청 - 사용자: {}, 채팅방명: {}, 이미지 키: {}",
-                userId, requestDto.getName(), requestDto.getRoomImageS3Key());
+        log.info("채팅방 생성 요청 - 사용자: {}, 채팅방명: {}, 이미지 URL: {}",
+                userId, requestDto.getName(), requestDto.getRoomImageUrl());
 
         ChatRoomResponseDto responseDto = chatService.createChatRoom(requestDto, userId);
 
@@ -77,6 +81,27 @@ public class ChatRoomController {
                 s3Service.generatePresignedUploadUrl(UploadType.GROUP, presignedUploadRequestDto);
 
         return ResponseEntity.ok(ApiResponse.success("채팅방 이미지 업로드 URL이 생성되었습니다.", responseDto));
+    }
+
+    @PostMapping("/room-image/upload-complete")
+    @Operation(
+            summary = "S3 채팅방 이미지 업로드 완료 처리",
+            description = "S3에 채팅방 이미지 업로드가 완료된 후 호출합니다. 서버에서 이미지 URL을 생성하여 반환합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<ChatRoomImageResponseDto>> saveRoomImageUrl(
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody UploadCompletedRequestDto uploadCompleteRequestDto) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        log.info("채팅방 이미지 업로드 완료 처리 - 사용자: {}, S3 키: {}",
+                userId, uploadCompleteRequestDto.getS3Key());
+
+        ChatRoomImageResponseDto responseDto = chatRoomImageService.processUploadedImage(
+                uploadCompleteRequestDto.getS3Key());
+
+        log.info("채팅방 이미지 URL 생성 완료 - 원본: {}", responseDto.getOriginalImageUrl());
+        return ResponseEntity.ok(ApiResponse.success("채팅방 이미지가 성공적으로 처리되었습니다.", responseDto));
     }
 
     @PostMapping("/one-to-one")

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
@@ -205,7 +205,7 @@ public class ChatRoomController {
     @PostMapping("/{chatroomId}/invite")
     @Operation(
             summary = "친구에게 초대 링크 전송",
-            description = "특정 친구에게 채팅방 초대 링크를 전송합니다. 링크를 받은 친구가 수락하면 채팅방에 참여됩니다.",
+            description = "특정 친구에게 채팅방 초대 링크를 전송합니다. 링크를 받은 친구가 수락하면 채팅방에 참여됩니다. 채팅방 참여자라면 누구나 초대할 수 있습니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<ChatInviteResponseDto>> sendInviteToFriend(
@@ -227,7 +227,7 @@ public class ChatRoomController {
     @PostMapping("/{chatroomId}/invite-link")
     @Operation(
             summary = "초대 링크 생성",
-            description = "채팅방 초대 링크를 생성합니다. 방장만 생성할 수 있으며 24시간 후 만료됩니다.",
+            description = "채팅방 초대 링크를 생성합니다. 채팅방 참여자라면 누구나 생성할 수 있으며 24시간 후 만료됩니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<ChatInviteResponseDto>> createInviteLink(
@@ -243,7 +243,7 @@ public class ChatRoomController {
         log.info("초대 링크 생성 완료 - 채팅방: {}, 만료시간: {}", chatroomId, responseDto.getExpiresAt());
         return ResponseEntity.ok(ApiResponse.success("초대 링크가 생성되었습니다.", responseDto));
     }
-
+    
     @PostMapping("/join")
     @Operation(
             summary = "초대 링크로 채팅방 참여",

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomUpdateReques
 import com.sonsminpark.auratalkback.domain.chat.dto.request.OneToOneChatRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatInviteResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatUserResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.service.ChatService;
 import com.sonsminpark.auratalkback.global.common.ApiResponse;
 import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
@@ -304,24 +305,44 @@ public class ChatRoomController {
 
     @PutMapping("/{chatroomId}/unban/{targetUserId}")
     @Operation(
-            summary = "채팅방 사용자 강퇴 해제",
-            description = "방장이 강퇴된 사용자의 강퇴를 해제합니다.",
+            summary = "채팅방 사용자 차단 해제",
+            description = "방장이 강퇴된 사용자의 차단을 해제합니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<Void>> unbanUser(
             @RequestHeader("Authorization") String authHeader,
             @Parameter(description = "채팅방 ID", required = true)
             @PathVariable Long chatroomId,
-            @Parameter(description = "강퇴 해제할 사용자 ID", required = true)
+            @Parameter(description = "채팅방 차단 해제할 사용자 ID", required = true)
             @PathVariable Long targetUserId) {
 
         Long userId = extractUserIdFromToken(authHeader);
-        log.info("사용자 강퇴 해제 요청 - 방장: {}, 채팅방: {}, 대상: {}", userId, chatroomId, targetUserId);
+        log.info("채팅방 사용자 차단 해제 요청 - 방장: {}, 채팅방: {}, 대상: {}", userId, chatroomId, targetUserId);
 
         chatService.unbanUser(chatroomId, userId, targetUserId);
 
-        log.info("사용자 강퇴 해제 완료 - 대상: {}, 채팅방: {}", targetUserId, chatroomId);
-        return ResponseEntity.ok(ApiResponse.success("사용자의 강퇴가 해제되었습니다."));
+        log.info("채팅방 사용자 차단 해제 완료 - 대상: {}, 채팅방: {}", targetUserId, chatroomId);
+        return ResponseEntity.ok(ApiResponse.success("채팅방 사용자의 차단이 해제되었습니다."));
+    }
+
+    @GetMapping("/{chatroomId}/banned-users")
+    @Operation(
+            summary = "채팅방 차단된 사용자 목록 조회",
+            description = "채팅방에서 차단된 사용자 목록을 조회합니다. 방장만 조회할 수 있습니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<List<ChatUserResponseDto>>> getBannedUsers(
+            @RequestHeader("Authorization") String authHeader,
+            @Parameter(description = "채팅방 ID", required = true)
+            @PathVariable Long chatroomId) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        log.debug("차단된 사용자 목록 조회 요청 - 사용자: {}, 채팅방: {}", userId, chatroomId);
+
+        List<ChatUserResponseDto> bannedUsers = chatService.getBannedUsers(chatroomId, userId);
+
+        log.debug("차단된 사용자 목록 조회 완료 - 채팅방: {}, 차단된 사용자 수: {}", chatroomId, bannedUsers.size());
+        return ResponseEntity.ok(ApiResponse.success("차단된 사용자 목록을 성공적으로 조회했습니다.", bannedUsers));
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
@@ -235,11 +235,6 @@ public class ChatRoomController {
         return ResponseEntity.ok(ApiResponse.success("알림 설정이 변경되었습니다."));
     }
 
-    private Long extractUserIdFromToken(String authHeader) {
-        String token = authHeader.substring(7); // "Bearer " 제거
-        return jwtTokenProvider.getUserIdFromToken(token);
-    }
-
     @DeleteMapping("/{chatroomId}/delete")
     @Operation(
             summary = "채팅방 삭제",
@@ -282,10 +277,32 @@ public class ChatRoomController {
         return ResponseEntity.ok(ApiResponse.success("사용자가 강퇴되었습니다."));
     }
 
+    @PutMapping("/{chatroomId}/unban/{targetUserId}")
+    @Operation(
+            summary = "채팅방 사용자 강퇴 해제",
+            description = "방장이 강퇴된 사용자의 강퇴를 해제합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<Void>> unbanUser(
+            @RequestHeader("Authorization") String authHeader,
+            @Parameter(description = "채팅방 ID", required = true)
+            @PathVariable Long chatroomId,
+            @Parameter(description = "강퇴 해제할 사용자 ID", required = true)
+            @PathVariable Long targetUserId) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        log.info("사용자 강퇴 해제 요청 - 방장: {}, 채팅방: {}, 대상: {}", userId, chatroomId, targetUserId);
+
+        chatService.unbanUser(chatroomId, userId, targetUserId);
+
+        log.info("사용자 강퇴 해제 완료 - 대상: {}, 채팅방: {}", targetUserId, chatroomId);
+        return ResponseEntity.ok(ApiResponse.success("사용자의 강퇴가 해제되었습니다."));
+    }
+
     @GetMapping("/search")
     @Operation(
             summary = "채팅방 검색",
-            description = "채팅방 이름으로 검색합니다.",
+            description = "채팅방 이름과 참여자 이름으로 검색합니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<List<ChatRoomResponseDto>>> searchChatRooms(
@@ -300,5 +317,10 @@ public class ChatRoomController {
 
         log.debug("채팅방 검색 완료 - 사용자: {}, 결과 수: {}", userId, chatRooms.size());
         return ResponseEntity.ok(ApiResponse.success("채팅방 검색이 완료되었습니다.", chatRooms));
+    }
+
+    private Long extractUserIdFromToken(String authHeader) {
+        String token = authHeader.substring(7); // "Bearer " 제거
+        return jwtTokenProvider.getUserIdFromToken(token);
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/ChatRoomController.java
@@ -9,6 +9,10 @@ import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto
 import com.sonsminpark.auratalkback.domain.chat.service.ChatService;
 import com.sonsminpark.auratalkback.global.common.ApiResponse;
 import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import com.sonsminpark.auratalkback.global.s3.S3Service;
+import com.sonsminpark.auratalkback.global.s3.UploadType;
+import com.sonsminpark.auratalkback.global.s3.dto.request.PresignedUploadRequestDto;
+import com.sonsminpark.auratalkback.global.s3.dto.response.PresignedUploadResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -31,12 +35,13 @@ import java.util.List;
 public class ChatRoomController {
 
     private final ChatService chatService;
+    private final S3Service s3Service;
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping
     @Operation(
             summary = "채팅방 만들기",
-            description = "새로운 채팅방을 생성합니다.",
+            description = "새로운 채팅방을 생성합니다. 채팅방 이미지를 설정하려면 roomImageS3Key를 포함하세요.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(
@@ -44,13 +49,33 @@ public class ChatRoomController {
             @Valid @RequestBody ChatRoomCreateRequestDto requestDto) {
 
         Long userId = extractUserIdFromToken(authHeader);
-        log.info("채팅방 생성 요청 - 사용자: {}, 채팅방명: {}", userId, requestDto.getName());
+        log.info("채팅방 생성 요청 - 사용자: {}, 채팅방명: {}, 이미지 키: {}",
+                userId, requestDto.getName(), requestDto.getRoomImageS3Key());
 
         ChatRoomResponseDto responseDto = chatService.createChatRoom(requestDto, userId);
 
         log.info("채팅방 생성 완료 - ID: {}, 이름: {}", responseDto.getId(), responseDto.getName());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("채팅방이 성공적으로 생성되었습니다.", responseDto));
+    }
+
+    @PostMapping("/room-image/presigned-url")
+    @Operation(
+            summary = "채팅방 이미지 업로드용 S3 PresignedUrl 생성",
+            description = "채팅방 이미지 업로드를 위한 S3 PresignedUrl을 생성합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<PresignedUploadResponseDto>> getRoomImageUploadUrl(
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody PresignedUploadRequestDto presignedUploadRequestDto) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        log.info("채팅방 이미지 업로드 URL 생성 요청 - 사용자: {}", userId);
+
+        PresignedUploadResponseDto responseDto =
+                s3Service.generatePresignedUploadUrl(UploadType.GROUP, presignedUploadRequestDto);
+
+        return ResponseEntity.ok(ApiResponse.success("채팅방 이미지 업로드 URL이 생성되었습니다.", responseDto));
     }
 
     @PostMapping("/one-to-one")

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/RandomChatController.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/controller/RandomChatController.java
@@ -1,0 +1,55 @@
+package com.sonsminpark.auratalkback.domain.chat.controller;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.RandomChatStartRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.RandomChatMatchResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.service.RandomChatService;
+import com.sonsminpark.auratalkback.global.common.ApiResponse;
+import com.sonsminpark.auratalkback.global.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/random-chat")
+@RequiredArgsConstructor
+@Tag(name = "RandomChat", description = "랜덤 채팅 관련 API")
+public class RandomChatController {
+
+    private final RandomChatService randomChatService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/start")
+    @Operation(
+            summary = "랜덤 채팅 시작",
+            description = "관심사 기반으로 랜덤 채팅을 시작합니다. 같은 관심사를 가진 사용자와 즉시 매칭하여 채팅방을 생성합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    public ResponseEntity<ApiResponse<RandomChatMatchResponseDto>> startRandomChat(
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody RandomChatStartRequestDto requestDto) {
+
+        Long userId = extractUserIdFromToken(authHeader);
+        log.info("랜덤 채팅 시작 요청 - 사용자: {}", userId);
+
+        RandomChatMatchResponseDto responseDto = randomChatService.startRandomChat(userId, requestDto);
+
+        if (responseDto.isMatched()) {
+            log.info("랜덤 채팅 매칭 성공 - 사용자: {}, 채팅방: {}", userId, responseDto.getChatRoom().getId());
+            return ResponseEntity.ok(ApiResponse.success("매칭이 완료되었습니다!", responseDto));
+        } else {
+            log.info("랜덤 채팅 매칭 실패 - 사용자: {}, 사유: {}", userId, responseDto.getMessage());
+            return ResponseEntity.ok(ApiResponse.success(responseDto.getMessage(), responseDto));
+        }
+    }
+
+    private Long extractUserIdFromToken(String authHeader) {
+        String token = authHeader.substring(7);
+        return jwtTokenProvider.getUserIdFromToken(token);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatFileUploadRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatFileUploadRequestDto.java
@@ -1,0 +1,24 @@
+package com.sonsminpark.auratalkback.domain.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatFileUploadRequestDto {
+
+    @NotBlank(message = "S3 키는 필수 입력값입니다.")
+    private String s3Key;
+
+    @NotBlank(message = "원본 파일명은 필수 입력값입니다.")
+    private String originalFileName;
+
+    @NotNull(message = "파일 크기는 필수 입력값입니다.")
+    private Long fileSize;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatRoomCreateRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatRoomCreateRequestDto.java
@@ -20,4 +20,6 @@ public class ChatRoomCreateRequestDto {
     private String name;
 
     private List<Long> userIds;
+
+    private String roomImageS3Key;
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatRoomCreateRequestDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/request/ChatRoomCreateRequestDto.java
@@ -21,5 +21,5 @@ public class ChatRoomCreateRequestDto {
 
     private List<Long> userIds;
 
-    private String roomImageS3Key;
+    private String roomImageUrl;
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatFileDownloadResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatFileDownloadResponseDto.java
@@ -1,0 +1,23 @@
+package com.sonsminpark.auratalkback.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatFileDownloadResponseDto {
+
+    private Long fileId;
+    private String originalFileName;
+    private String downloadUrl;
+    private LocalDateTime expiresAt;
+    private Long fileSize;
+    private String formattedFileSize;
+    private String mimeType;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatFileResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatFileResponseDto.java
@@ -1,0 +1,58 @@
+package com.sonsminpark.auratalkback.domain.chat.dto.response;
+
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatFile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatFileResponseDto {
+
+    private Long fileId;
+    private Long chatroomId;
+    private Long messageId;
+    private String originalFileName;
+    private String fileExtension;
+    private String mimeType;
+    private Long fileSize;
+    private String formattedFileSize;
+    private boolean isImage;
+    private boolean isVideo;
+    private boolean isAudio;
+    private ChatUserResponseDto uploader;
+    private LocalDateTime createdAt;
+    private boolean isDeleted;
+
+    public static ChatFileResponseDto from(ChatFile chatFile) {
+        return ChatFileResponseDto.builder()
+                .fileId(chatFile.getId())
+                .chatroomId(chatFile.getChatRoom().getId())
+                .messageId(chatFile.getMessage() != null ? chatFile.getMessage().getId() : null)
+                .originalFileName(chatFile.getOriginalFileName())
+                .fileExtension(chatFile.getFileExtension())
+                .mimeType(chatFile.getMimeType())
+                .fileSize(chatFile.getFileSize())
+                .formattedFileSize(chatFile.getFormattedFileSize())
+                .isImage(chatFile.isImage())
+                .isVideo(chatFile.isVideo())
+                .isAudio(chatFile.isAudio())
+                .uploader(ChatUserResponseDto.from(chatFile.getUploader()))
+                .createdAt(chatFile.getCreatedAt())
+                .isDeleted(chatFile.isDeleted())
+                .build();
+    }
+
+    public static ChatFileResponseDto from(ChatFile chatFile, String uploaderThumbnailUrl) {
+        ChatFileResponseDto dto = from(chatFile);
+        if (dto.getUploader() != null) {
+            dto.getUploader().setThumbnailImageUrl(uploaderThumbnailUrl);
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatRoomImageResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatRoomImageResponseDto.java
@@ -1,0 +1,17 @@
+package com.sonsminpark.auratalkback.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomImageResponseDto {
+
+    private String originalImageUrl;
+    private String thumbnailImageUrl;
+    private boolean isDefaultImage;
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/dto/response/ChatRoomResponseDto.java
@@ -29,6 +29,10 @@ public class ChatRoomResponseDto {
     private String inviteCode;
     private LocalDateTime inviteCodeExpiredAt;
 
+    public boolean isOwner() {
+        return this.isOwner;
+    }
+
     public static ChatRoomResponseDto from(ChatRoom chatRoom) {
         return ChatRoomResponseDto.builder()
                 .id(chatRoom.getId())

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatFile.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatFile.java
@@ -1,0 +1,93 @@
+package com.sonsminpark.auratalkback.domain.chat.entity;
+
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "chat_files")
+public class ChatFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploader_id", nullable = false)
+    private User uploader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = true)
+    private ChatMessage message;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false)
+    private String s3Key;
+
+    @Column(nullable = false)
+    private String s3Url;
+
+    @Column(nullable = false)
+    private String fileExtension;
+
+    @Column(nullable = false)
+    private String mimeType;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
+
+    public void setMessage(ChatMessage message) {
+        this.message = message;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isImage() {
+        return mimeType.startsWith("image/");
+    }
+
+    public boolean isVideo() {
+        return mimeType.startsWith("video/");
+    }
+
+    public boolean isAudio() {
+        return mimeType.startsWith("audio/");
+    }
+
+    public String getFormattedFileSize() {
+        if (fileSize < 1024) {
+            return fileSize + " B";
+        } else if (fileSize < 1024 * 1024) {
+            return String.format("%.1f KB", fileSize / 1024.0);
+        } else if (fileSize < 1024 * 1024 * 1024) {
+            return String.format("%.1f MB", fileSize / (1024.0 * 1024.0));
+        } else {
+            return String.format("%.1f GB", fileSize / (1024.0 * 1024.0 * 1024.0));
+        }
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatRoom.java
@@ -4,6 +4,7 @@ import com.sonsminpark.auratalkback.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -15,6 +16,18 @@ import java.util.Set;
 @Builder
 @Entity
 @Table(name = "chat_rooms")
+@NamedEntityGraph(
+        name = "ChatRoom.withOwner",
+        attributeNodes = {
+                @NamedAttributeNode(value = "owner", subgraph = "owner.profile")
+        },
+        subgraphs = {
+                @NamedSubgraph(
+                        name = "owner.profile",
+                        attributeNodes = @NamedAttributeNode("userProfileImage")
+                )
+        }
+)
 public class ChatRoom {
 
     @Id
@@ -32,13 +45,14 @@ public class ChatRoom {
     @JoinColumn(name = "owner_id")
     private User owner;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "chatroom_banned_users",
             joinColumns = @JoinColumn(name = "chatroom_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id")
     )
     @Builder.Default
+    @BatchSize(size = 10)
     private Set<User> bannedUsers = new HashSet<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/entity/ChatRoom.java
@@ -6,6 +6,8 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,6 +32,15 @@ public class ChatRoom {
     @JoinColumn(name = "owner_id")
     private User owner;
 
+    @ManyToMany
+    @JoinTable(
+            name = "chatroom_banned_users",
+            joinColumns = @JoinColumn(name = "chatroom_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    @Builder.Default
+    private Set<User> bannedUsers = new HashSet<>();
+
     @Column(nullable = false)
     @Builder.Default
     private boolean isActive = true;
@@ -47,6 +58,19 @@ public class ChatRoom {
 
     @Column
     private String roomImageUrl;
+
+    public void banUser(User user) {
+        this.bannedUsers.add(user);
+    }
+
+    public void unbanUser(User user) {
+        this.bannedUsers.remove(user);
+    }
+
+    public boolean isBannedUser(Long userId) {
+        return this.bannedUsers.stream()
+                .anyMatch(user -> user.getId().equals(userId));
+    }
 
     public void updateName(String name) {
         this.name = name;

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatFileNotFoundException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatFileNotFoundException.java
@@ -1,0 +1,18 @@
+package com.sonsminpark.auratalkback.domain.chat.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+public class ChatFileNotFoundException extends BusinessException {
+    private ChatFileNotFoundException(String message) {
+        super(ErrorCode.ENTITY_NOT_FOUND, message);
+    }
+
+    public static ChatFileNotFoundException of(String message) {
+        return new ChatFileNotFoundException(message);
+    }
+
+    public static ChatFileNotFoundException of(Long fileId) {
+        return new ChatFileNotFoundException("파일을 찾을 수 없습니다. ID: " + fileId);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatFileUploadException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatFileUploadException.java
@@ -1,0 +1,14 @@
+package com.sonsminpark.auratalkback.domain.chat.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+public class ChatFileUploadException extends BusinessException {
+    private ChatFileUploadException(String message) {
+        super(ErrorCode.FILE_UPLOAD_ERROR, message);
+    }
+
+    public static ChatFileUploadException fileSizeExceeded(long maxSize) {
+        return new ChatFileUploadException("파일 크기가 너무 큽니다. 최대 " + (maxSize / (1024 * 1024)) + "MB까지 업로드 가능합니다.");
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatRoomBannedException.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/exception/ChatRoomBannedException.java
@@ -1,0 +1,22 @@
+package com.sonsminpark.auratalkback.domain.chat.exception;
+
+import com.sonsminpark.auratalkback.global.exception.BusinessException;
+import com.sonsminpark.auratalkback.global.exception.ErrorCode;
+
+public class ChatRoomBannedException extends BusinessException {
+    private ChatRoomBannedException() {
+        super(ErrorCode.CHAT_ACCESS_DENIED);
+    }
+
+    private ChatRoomBannedException(String message) {
+        super(ErrorCode.CHAT_ACCESS_DENIED, message);
+    }
+
+    public static ChatRoomBannedException of() {
+        return new ChatRoomBannedException("강퇴된 채팅방에는 다시 입장할 수 없습니다.");
+    }
+
+    public static ChatRoomBannedException of(String chatRoomName) {
+        return new ChatRoomBannedException("'" + chatRoomName + "' 채팅방에서 강퇴되어 입장할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatFileRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatFileRepository.java
@@ -15,9 +15,11 @@ import java.util.Optional;
 public interface ChatFileRepository extends JpaRepository<ChatFile, Long> {
 
     @Query("SELECT cf FROM ChatFile cf " +
+            "JOIN FETCH cf.uploader u " +
+            "LEFT JOIN FETCH u.userProfileImage " +
             "WHERE cf.chatRoom.id = :chatroomId AND cf.isDeleted = false " +
             "ORDER BY cf.createdAt DESC")
-    Page<ChatFile> findByChatRoomIdAndIsDeletedFalse(
+    Page<ChatFile> findByChatRoomIdWithUploader(
             @Param("chatroomId") Long chatroomId,
             Pageable pageable);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatFileRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatFileRepository.java
@@ -1,0 +1,43 @@
+package com.sonsminpark.auratalkback.domain.chat.repository;
+
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatFile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatFileRepository extends JpaRepository<ChatFile, Long> {
+
+    @Query("SELECT cf FROM ChatFile cf " +
+            "WHERE cf.chatRoom.id = :chatroomId AND cf.isDeleted = false " +
+            "ORDER BY cf.createdAt DESC")
+    Page<ChatFile> findByChatRoomIdAndIsDeletedFalse(
+            @Param("chatroomId") Long chatroomId,
+            Pageable pageable);
+
+    @Query("SELECT cf FROM ChatFile cf " +
+            "WHERE cf.id = :fileId AND cf.uploader.id = :uploaderId AND cf.isDeleted = false")
+    Optional<ChatFile> findByIdAndUploaderIdAndIsDeletedFalse(
+            @Param("fileId") Long fileId,
+            @Param("uploaderId") Long uploaderId);
+
+    @Query("SELECT cf FROM ChatFile cf " +
+            "WHERE cf.id = :fileId AND cf.isDeleted = false")
+    Optional<ChatFile> findByIdAndIsDeletedFalse(@Param("fileId") Long fileId);
+
+    @Query("SELECT cf FROM ChatFile cf " +
+            "WHERE cf.chatRoom.id = :chatroomId AND cf.mimeType LIKE 'image/%' AND cf.isDeleted = false " +
+            "ORDER BY cf.createdAt DESC")
+    List<ChatFile> findImagesByChatRoomId(@Param("chatroomId") Long chatroomId);
+
+    @Query("SELECT cf FROM ChatFile cf " +
+            "WHERE cf.chatRoom.id = :chatroomId AND cf.mimeType LIKE 'video/%' AND cf.isDeleted = false " +
+            "ORDER BY cf.createdAt DESC")
+    List<ChatFile> findVideosByChatRoomId(@Param("chatroomId") Long chatroomId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatMessageRepository.java
@@ -13,8 +13,12 @@ import java.util.Optional;
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.isDeleted = false ORDER BY cm.createdAt DESC")
-    Page<ChatMessage> findByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+    @Query("SELECT cm FROM ChatMessage cm " +
+            "LEFT JOIN FETCH cm.sender s " +
+            "LEFT JOIN FETCH s.userProfileImage " +
+            "WHERE cm.chatRoom.id = :chatRoomId AND cm.isDeleted = false " +
+            "ORDER BY cm.createdAt DESC")
+    Page<ChatMessage> findByChatRoomIdWithSender(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
 
     @Query("SELECT cm FROM ChatMessage cm WHERE cm.id = :messageId AND cm.sender.id = :senderId AND cm.isDeleted = false")
     Optional<ChatMessage> findByIdAndSenderId(@Param("messageId") Long messageId, @Param("senderId") Long senderId);

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
@@ -58,4 +58,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "LEFT JOIN FETCH o.userProfileImage " +
             "WHERE cr.id = :chatRoomId")
     Optional<ChatRoom> findByIdWithOwner(@Param("chatRoomId") Long chatRoomId);
+
+    @Query("SELECT cr FROM ChatRoom cr " +
+            "LEFT JOIN FETCH cr.bannedUsers bu " +
+            "LEFT JOIN FETCH bu.userProfileImage " +
+            "WHERE cr.id = :chatRoomId")
+    Optional<ChatRoom> findByIdWithBannedUsers(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
@@ -13,11 +13,13 @@ import java.util.Optional;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("SELECT cr FROM ChatRoom cr " +
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+            "LEFT JOIN FETCH cr.owner o " +
+            "LEFT JOIN FETCH o.userProfileImage " +
             "JOIN ChatRoomUser cru ON cr.id = cru.chatRoom.id " +
             "WHERE cru.user.id = :userId " +
             "ORDER BY cr.lastMessageAt DESC")
-    List<ChatRoom> findActiveByUserId(@Param("userId") Long userId);
+    List<ChatRoom> findActiveByUserIdWithOwner(@Param("userId") Long userId);
 
     @Query("SELECT cr FROM ChatRoom cr " +
             "JOIN ChatRoomUser cru1 ON cr.id = cru1.chatRoom.id " +
@@ -50,4 +52,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "OR LOWER(u.username) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
             "ORDER BY cr.lastMessageAt DESC")
     List<ChatRoom> searchByNameAndUserId(@Param("keyword") String keyword, @Param("userId") Long userId);
+
+    @Query("SELECT cr FROM ChatRoom cr " +
+            "LEFT JOIN FETCH cr.owner o " +
+            "LEFT JOIN FETCH o.userProfileImage " +
+            "WHERE cr.id = :chatRoomId")
+    Optional<ChatRoom> findByIdWithOwner(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomRepository.java
@@ -40,10 +40,14 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT cr FROM ChatRoom cr WHERE LOWER(cr.name) LIKE LOWER(CONCAT('%', :keyword, '%')) AND cr.isActive = true")
     List<ChatRoom> searchByName(@Param("keyword") String keyword);
 
-    @Query("SELECT cr FROM ChatRoom cr " +
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
             "JOIN ChatRoomUser cru ON cr.id = cru.chatRoom.id " +
+            "LEFT JOIN ChatRoomUser cru2 ON cr.id = cru2.chatRoom.id " +
+            "LEFT JOIN cru2.user u ON u.id = cru2.user.id " +
             "WHERE cru.user.id = :userId AND cr.isActive = true " +
-            "AND LOWER(cr.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "AND (LOWER(cr.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(u.username) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
             "ORDER BY cr.lastMessageAt DESC")
     List<ChatRoom> searchByNameAndUserId(@Param("keyword") String keyword, @Param("userId") Long userId);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/repository/ChatRoomUserRepository.java
@@ -19,8 +19,11 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
 
     void deleteAllByChatRoomId(Long chatRoomId);
 
-    @Query("SELECT cru FROM ChatRoomUser cru JOIN FETCH cru.user WHERE cru.chatRoom.id = :chatRoomId")
-    List<ChatRoomUser> findAllByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+    @Query("SELECT cru FROM ChatRoomUser cru " +
+            "JOIN FETCH cru.user u " +
+            "LEFT JOIN FETCH u.userProfileImage " +
+            "WHERE cru.chatRoom.id = :chatRoomId")
+    List<ChatRoomUser> findAllByChatRoomIdWithUserAndProfile(@Param("chatRoomId") Long chatRoomId);
 
     @Query("SELECT COUNT(cru) FROM ChatRoomUser cru WHERE cru.chatRoom.id = :chatRoomId")
     long countByChatRoomId(@Param("chatRoomId") Long chatRoomId);

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileService.java
@@ -1,0 +1,20 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatFileUploadRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileDownloadResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileResponseDto;
+
+import java.util.List;
+
+public interface ChatFileService {
+
+    void validateChatRoomAccess(Long chatroomId, Long userId);
+
+    ChatFileResponseDto completeFileUpload(Long chatroomId, Long userId, ChatFileUploadRequestDto requestDto);
+
+    ChatFileDownloadResponseDto generateDownloadUrl(Long fileId, Long userId);
+
+    List<ChatFileResponseDto> getChatRoomFiles(Long chatroomId, Long userId, int page, int size);
+
+    void deleteFile(Long fileId, Long userId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileServiceImpl.java
@@ -3,12 +3,11 @@ package com.sonsminpark.auratalkback.domain.chat.service;
 import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatFileUploadRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileDownloadResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileResponseDto;
-import com.sonsminpark.auratalkback.domain.chat.entity.*;
-import com.sonsminpark.auratalkback.domain.chat.exception.ChatAccessDeniedException;
-import com.sonsminpark.auratalkback.domain.chat.exception.ChatRoomNotFoundException;
-import com.sonsminpark.auratalkback.domain.chat.exception.InvalidChatRoomStateException;
-import com.sonsminpark.auratalkback.domain.chat.exception.ChatFileNotFoundException;
-import com.sonsminpark.auratalkback.domain.chat.exception.ChatFileUploadException;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatFile;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatMessage;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatRoom;
+import com.sonsminpark.auratalkback.domain.chat.entity.MessageType;
+import com.sonsminpark.auratalkback.domain.chat.exception.*;
 import com.sonsminpark.auratalkback.domain.chat.repository.ChatFileRepository;
 import com.sonsminpark.auratalkback.domain.chat.repository.ChatMessageRepository;
 import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomRepository;
@@ -16,7 +15,6 @@ import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomUserRepositor
 import com.sonsminpark.auratalkback.domain.user.entity.User;
 import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
 import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
-import com.sonsminpark.auratalkback.domain.user.service.UserProfileImageService;
 import com.sonsminpark.auratalkback.global.s3.FileUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +45,6 @@ public class ChatFileServiceImpl implements ChatFileService {
     private final ChatRoomUserRepository chatRoomUserRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
-    private final UserProfileImageService userProfileImageService;
     private final SimpMessagingTemplate messagingTemplate;
     private final S3Presigner s3Presigner;
 
@@ -122,8 +119,9 @@ public class ChatFileServiceImpl implements ChatFileService {
 
         chatRoom.updateLastMessageAt();
 
-        // WebSocket으로 실시간 전송
-        String uploaderThumbnailUrl = getUserThumbnailUrl(uploader.getId());
+        String uploaderThumbnailUrl = uploader.getUserProfileImage() != null ?
+                uploader.getUserProfileImage().getThumbnailImageUrl() : null;
+
         ChatFileResponseDto responseDto = ChatFileResponseDto.from(savedChatFile, uploaderThumbnailUrl);
 
         messagingTemplate.convertAndSend("/topic/chatroom/" + chatroomId + "/files", responseDto);
@@ -174,11 +172,13 @@ public class ChatFileServiceImpl implements ChatFileService {
         validateChatRoomAccess(chatroomId, userId);
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        Page<ChatFile> chatFiles = chatFileRepository.findByChatRoomIdAndIsDeletedFalse(chatroomId, pageable);
+
+        Page<ChatFile> chatFiles = chatFileRepository.findByChatRoomIdWithUploader(chatroomId, pageable);
 
         return chatFiles.stream()
                 .map(chatFile -> {
-                    String uploaderThumbnailUrl = getUserThumbnailUrl(chatFile.getUploader().getId());
+                    String uploaderThumbnailUrl = chatFile.getUploader().getUserProfileImage() != null ?
+                            chatFile.getUploader().getUserProfileImage().getThumbnailImageUrl() : null;
                     return ChatFileResponseDto.from(chatFile, uploaderThumbnailUrl);
                 })
                 .toList();
@@ -212,15 +212,6 @@ public class ChatFileServiceImpl implements ChatFileService {
                 .orElseThrow(() -> UserNotFoundException.of(userId));
     }
 
-    private String getUserThumbnailUrl(Long userId) {
-        try {
-            return userProfileImageService.getProfileImage(userId).getThumbnailImageUrl();
-        } catch (Exception e) {
-            log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", userId, e.getMessage());
-            return null;
-        }
-    }
-
     private MessageType determineMessageType(String mimeType) {
         if (mimeType.startsWith("image/")) {
             return MessageType.IMAGE;
@@ -231,12 +222,5 @@ public class ChatFileServiceImpl implements ChatFileService {
         } else {
             return MessageType.FILE;
         }
-    }
-
-    private String createFileMessageContent(String fileName, String description) {
-        if (description != null && !description.trim().isEmpty()) {
-            return fileName + "\n" + description.trim();
-        }
-        return fileName;
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatFileServiceImpl.java
@@ -1,0 +1,242 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatFileUploadRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileDownloadResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatFileResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.entity.*;
+import com.sonsminpark.auratalkback.domain.chat.exception.ChatAccessDeniedException;
+import com.sonsminpark.auratalkback.domain.chat.exception.ChatRoomNotFoundException;
+import com.sonsminpark.auratalkback.domain.chat.exception.InvalidChatRoomStateException;
+import com.sonsminpark.auratalkback.domain.chat.exception.ChatFileNotFoundException;
+import com.sonsminpark.auratalkback.domain.chat.exception.ChatFileUploadException;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatFileRepository;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatMessageRepository;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomRepository;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomUserRepository;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import com.sonsminpark.auratalkback.domain.user.service.UserProfileImageService;
+import com.sonsminpark.auratalkback.global.s3.FileUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatFileServiceImpl implements ChatFileService {
+
+    private final ChatFileRepository chatFileRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    private final UserProfileImageService userProfileImageService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private static final long MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+    private static final int DOWNLOAD_URL_EXPIRY_HOURS = 1; // 1시간
+
+    @Override
+    @Transactional(readOnly = true)
+    public void validateChatRoomAccess(Long chatroomId, Long userId) {
+        ChatRoom chatRoom = findChatRoomById(chatroomId);
+
+        if (!chatRoom.isActive()) {
+            throw InvalidChatRoomStateException.deactivated();
+        }
+
+        if (chatRoom.isBannedUser(userId)) {
+            throw ChatAccessDeniedException.of("강퇴된 채팅방에는 파일을 업로드할 수 없습니다.");
+        }
+
+        boolean isUserInChatRoom = chatRoomUserRepository.findByChatRoomIdAndUserId(chatroomId, userId).isPresent();
+        if (!isUserInChatRoom) {
+            throw ChatAccessDeniedException.of("채팅방에 참여하고 있지 않습니다.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public ChatFileResponseDto completeFileUpload(Long chatroomId, Long userId, ChatFileUploadRequestDto requestDto) {
+        ChatRoom chatRoom = findChatRoomById(chatroomId);
+        User uploader = findUserById(userId);
+
+        validateChatRoomAccess(chatroomId, userId);
+
+        if (requestDto.getFileSize() > MAX_FILE_SIZE) {
+            throw ChatFileUploadException.fileSizeExceeded(MAX_FILE_SIZE);
+        }
+
+        String originalFileName = requestDto.getOriginalFileName();
+        String fileExtension = FileUtil.extractExtension(originalFileName);
+        String mimeType = FileUtil.getMimeType(fileExtension);
+        String s3Url = "https://" + bucketName + ".s3.amazonaws.com/" + requestDto.getS3Key();
+
+        ChatFile chatFile = ChatFile.builder()
+                .chatRoom(chatRoom)
+                .uploader(uploader)
+                .originalFileName(originalFileName)
+                .s3Key(requestDto.getS3Key())
+                .s3Url(s3Url)
+                .fileExtension(fileExtension)
+                .mimeType(mimeType)
+                .fileSize(requestDto.getFileSize())
+                .build();
+
+        ChatFile savedChatFile = chatFileRepository.save(chatFile);
+
+        MessageType messageType = determineMessageType(mimeType);
+        String messageContent = originalFileName;
+
+        ChatMessage fileMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .sender(uploader)
+                .content(messageContent)
+                .type(messageType)
+                .build();
+
+        ChatMessage savedMessage = chatMessageRepository.save(fileMessage);
+
+        savedChatFile.setMessage(savedMessage);
+
+        chatRoom.updateLastMessageAt();
+
+        // WebSocket으로 실시간 전송
+        String uploaderThumbnailUrl = getUserThumbnailUrl(uploader.getId());
+        ChatFileResponseDto responseDto = ChatFileResponseDto.from(savedChatFile, uploaderThumbnailUrl);
+
+        messagingTemplate.convertAndSend("/topic/chatroom/" + chatroomId + "/files", responseDto);
+
+        log.info("파일 업로드 완료 - 파일 ID: {}, 채팅방: {}, 업로더: {}",
+                savedChatFile.getId(), chatroomId, userId);
+
+        return responseDto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatFileDownloadResponseDto generateDownloadUrl(Long fileId, Long userId) {
+        ChatFile chatFile = chatFileRepository.findByIdAndIsDeletedFalse(fileId)
+                .orElseThrow(() -> ChatFileNotFoundException.of("파일을 찾을 수 없습니다."));
+
+        validateChatRoomAccess(chatFile.getChatRoom().getId(), userId);
+
+        // PresignedURL 생성
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(chatFile.getS3Key())
+                .responseContentDisposition("attachment; filename=\"" + chatFile.getOriginalFileName() + "\"")
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .getObjectRequest(getObjectRequest)
+                .signatureDuration(Duration.ofHours(DOWNLOAD_URL_EXPIRY_HOURS))
+                .build();
+
+        URL url = s3Presigner.presignGetObject(presignRequest).url();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(DOWNLOAD_URL_EXPIRY_HOURS);
+
+        return ChatFileDownloadResponseDto.builder()
+                .fileId(fileId)
+                .originalFileName(chatFile.getOriginalFileName())
+                .downloadUrl(url.toString())
+                .expiresAt(expiresAt)
+                .fileSize(chatFile.getFileSize())
+                .formattedFileSize(chatFile.getFormattedFileSize())
+                .mimeType(chatFile.getMimeType())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatFileResponseDto> getChatRoomFiles(Long chatroomId, Long userId, int page, int size) {
+        validateChatRoomAccess(chatroomId, userId);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<ChatFile> chatFiles = chatFileRepository.findByChatRoomIdAndIsDeletedFalse(chatroomId, pageable);
+
+        return chatFiles.stream()
+                .map(chatFile -> {
+                    String uploaderThumbnailUrl = getUserThumbnailUrl(chatFile.getUploader().getId());
+                    return ChatFileResponseDto.from(chatFile, uploaderThumbnailUrl);
+                })
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void deleteFile(Long fileId, Long userId) {
+        ChatFile chatFile = chatFileRepository.findByIdAndUploaderIdAndIsDeletedFalse(fileId, userId)
+                .orElseThrow(() -> ChatFileNotFoundException.of("파일을 찾을 수 없거나 삭제 권한이 없습니다."));
+
+        chatFile.softDelete();
+
+        if (chatFile.getMessage() != null) {
+            chatFile.getMessage().softDelete();
+        }
+
+        messagingTemplate.convertAndSend("/topic/chatroom/" + chatFile.getChatRoom().getId() + "/files/deleted",
+                ChatFileResponseDto.from(chatFile));
+
+        log.info("파일 삭제 완료 - 파일 ID: {}, 사용자: {}", fileId, userId);
+    }
+
+    private ChatRoom findChatRoomById(Long chatroomId) {
+        return chatRoomRepository.findById(chatroomId)
+                .orElseThrow(() -> ChatRoomNotFoundException.of(chatroomId));
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+    }
+
+    private String getUserThumbnailUrl(Long userId) {
+        try {
+            return userProfileImageService.getProfileImage(userId).getThumbnailImageUrl();
+        } catch (Exception e) {
+            log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", userId, e.getMessage());
+            return null;
+        }
+    }
+
+    private MessageType determineMessageType(String mimeType) {
+        if (mimeType.startsWith("image/")) {
+            return MessageType.IMAGE;
+        } else if (mimeType.startsWith("video/")) {
+            return MessageType.VIDEO;
+        } else if (mimeType.startsWith("audio/")) {
+            return MessageType.VOICE;
+        } else {
+            return MessageType.FILE;
+        }
+    }
+
+    private String createFileMessageContent(String fileName, String description) {
+        if (description != null && !description.trim().isEmpty()) {
+            return fileName + "\n" + description.trim();
+        }
+        return fileName;
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageService.java
@@ -1,0 +1,12 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomImageResponseDto;
+
+public interface ChatRoomImageService {
+
+    // S3 업로드 완료 후 채팅방 이미지 URL 생성
+    ChatRoomImageResponseDto processUploadedImage(String s3Key);
+
+    // 채팅방 ID를 기반으로 기본 이미지 정보 생성
+    ChatRoomImageResponseDto getDefaultImage(Long chatRoomId);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
@@ -36,18 +36,36 @@ public class ChatRoomImageServiceImpl implements ChatRoomImageService {
     public ChatRoomImageResponseDto getDefaultImage(Long chatRoomId) {
         log.debug("채팅방 기본 이미지 생성 - 채팅방 ID: {}", chatRoomId);
 
-        int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
-        String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+        try {
+            int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
 
-        String originalImageUrl = prefix + index + ".png";
-        String thumbnailImageUrl = prefix + index + "_thumb.png";
+            // 범위 체크
+            if (index < 1 || index > DEFAULT_GROUP_IMAGE_COUNT) {
+                index = 1;
+            }
 
-        log.debug("채팅방 기본 이미지 생성 완료 - 원본: {}", originalImageUrl);
+            String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
 
-        return ChatRoomImageResponseDto.builder()
-                .originalImageUrl(originalImageUrl)
-                .thumbnailImageUrl(thumbnailImageUrl)
-                .isDefaultImage(true)
-                .build();
+            String originalImageUrl = prefix + index + ".png";
+            String thumbnailImageUrl = prefix + index + "_thumb.png";
+
+            log.debug("채팅방 기본 이미지 생성 완료 - 원본: {}, 썸네일: {}", originalImageUrl, thumbnailImageUrl);
+
+            return ChatRoomImageResponseDto.builder()
+                    .originalImageUrl(originalImageUrl)
+                    .thumbnailImageUrl(thumbnailImageUrl)
+                    .isDefaultImage(true)
+                    .build();
+        } catch (Exception e) {
+            log.error("채팅방 기본 이미지 생성 실패 - ID: {}, 에러: {}", chatRoomId, e.getMessage(), e);
+
+            // 오류 발생 시 기본값
+            String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+            return ChatRoomImageResponseDto.builder()
+                    .originalImageUrl(prefix + "1.png")
+                    .thumbnailImageUrl(prefix + "1_thumb.png")
+                    .isDefaultImage(true)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
@@ -37,7 +37,7 @@ public class ChatRoomImageServiceImpl implements ChatRoomImageService {
         log.debug("채팅방 기본 이미지 생성 - 채팅방 ID: {}", chatRoomId);
 
         try {
-            int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+            int index = (int) (chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
 
             // 범위 체크
             if (index < 1 || index > DEFAULT_GROUP_IMAGE_COUNT) {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatRoomImageServiceImpl.java
@@ -1,0 +1,53 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomImageResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomImageServiceImpl implements ChatRoomImageService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private static final int DEFAULT_GROUP_IMAGE_COUNT = 2;
+
+    @Override
+    public ChatRoomImageResponseDto processUploadedImage(String s3Key) {
+        log.info("채팅방 이미지 업로드 완료 처리 - S3 키: {}", s3Key);
+
+        String originalImageUrl = "https://" + bucketName + ".s3.amazonaws.com/" + s3Key;
+        String thumbnailImageUrl = originalImageUrl.replace("/original/", "/thumbnail/");
+
+        log.info("채팅방 이미지 URL 생성 완료 - 원본: {}, 썸네일: {}", originalImageUrl, thumbnailImageUrl);
+
+        return ChatRoomImageResponseDto.builder()
+                .originalImageUrl(originalImageUrl)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .isDefaultImage(false)
+                .build();
+    }
+
+    @Override
+    public ChatRoomImageResponseDto getDefaultImage(Long chatRoomId) {
+        log.debug("채팅방 기본 이미지 생성 - 채팅방 ID: {}", chatRoomId);
+
+        int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+        String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+
+        String originalImageUrl = prefix + index + ".png";
+        String thumbnailImageUrl = prefix + index + "_thumb.png";
+
+        log.debug("채팅방 기본 이미지 생성 완료 - 원본: {}", originalImageUrl);
+
+        return ChatRoomImageResponseDto.builder()
+                .originalImageUrl(originalImageUrl)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .isDefaultImage(true)
+                .build();
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatService.java
@@ -30,6 +30,8 @@ public interface ChatService {
 
     void kickUser(Long chatRoomId, Long ownerId, Long targetUserId);
 
+    void unbanUser(Long chatRoomId, Long ownerId, Long targetUserId);
+
     List<ChatRoomResponseDto> searchChatRooms(String keyword, Long userId);
 
     // 메시지

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatService.java
@@ -7,6 +7,7 @@ import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomUpdateReques
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatInviteResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatMessageResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatUserResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -31,6 +32,8 @@ public interface ChatService {
     void kickUser(Long chatRoomId, Long ownerId, Long targetUserId);
 
     void unbanUser(Long chatRoomId, Long ownerId, Long targetUserId);
+
+    List<ChatUserResponseDto> getBannedUsers(Long chatRoomId, Long userId);
 
     List<ChatRoomResponseDto> searchChatRooms(String keyword, Long userId);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -418,7 +418,8 @@ public class ChatServiceImpl implements ChatService {
     public ChatInviteResponseDto createInviteLink(Long chatRoomId, Long userId) {
         ChatRoom chatRoom = findChatRoomById(chatRoomId);
 
-        validateOwnerPermission(chatRoom, userId);
+        // 채팅방 접근 권한 검증
+        validateChatRoomAccess(chatRoomId, userId);
         validateChatRoomActive(chatRoom);
 
         String inviteCode = UUID.randomUUID().toString();
@@ -444,6 +445,7 @@ public class ChatServiceImpl implements ChatService {
         User inviter = findUserById(userId);
         User invitee = findUserById(requestDto.getUserId());
 
+        // 채팅방 접근 권한 검증
         validateChatRoomAccess(chatRoomId, userId);
         validateChatRoomActive(chatRoom);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -56,7 +56,7 @@ public class ChatServiceImpl implements ChatService {
     private DefaultGroupImage getDefaultGroupImage(Long chatRoomId) {
         try {
             // 항상 1 또는 2만 반환
-            int index = (int) ((chatRoomId - 1) % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+            int index = (int) (chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
 
             // 범위 체크
             if (index < 1 || index > DEFAULT_GROUP_IMAGE_COUNT) {
@@ -580,47 +580,73 @@ public class ChatServiceImpl implements ChatService {
     }
 
     private ChatRoomResponseDto buildChatRoomResponse(ChatRoom chatRoom, Long currentUserId) {
-        ChatRoomResponseDto dto = ChatRoomResponseDto.from(chatRoom, currentUserId);
+        try {
+            ChatRoomResponseDto dto = ChatRoomResponseDto.from(chatRoom, currentUserId);
 
-        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomIdWithUserAndProfile(chatRoom.getId());
+            List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomIdWithUserAndProfile(chatRoom.getId());
 
-        List<ChatUserResponseDto> users = roomUsers.stream()
-                .map(roomUser -> {
-                    User user = roomUser.getUser();
-                    String thumbnailUrl = user.getUserProfileImage() != null ?
-                            user.getUserProfileImage().getThumbnailImageUrl() : null;
-                    return ChatUserResponseDto.from(user, thumbnailUrl);
-                })
-                .toList();
+            List<ChatUserResponseDto> users = roomUsers.stream()
+                    .map(roomUser -> {
+                        User user = roomUser.getUser();
+                        String thumbnailUrl = user.getUserProfileImage() != null ?
+                                user.getUserProfileImage().getThumbnailImageUrl() : null;
+                        return ChatUserResponseDto.from(user, thumbnailUrl);
+                    })
+                    .toList();
 
-        dto.setUsers(users);
+            dto.setUsers(users);
 
-        if (chatRoom.getOwner() != null && chatRoom.getOwner().getUserProfileImage() != null) {
-            dto.setOwnerThumbnailUrl(chatRoom.getOwner().getUserProfileImage().getThumbnailImageUrl());
-        }
+            if (chatRoom.getOwner() != null && chatRoom.getOwner().getUserProfileImage() != null) {
+                dto.setOwnerThumbnailUrl(chatRoom.getOwner().getUserProfileImage().getThumbnailImageUrl());
+            }
 
-        // 그룹 채팅방인 경우 기본 이미지 설정
-        if (chatRoom.getType() == ChatRoomType.GROUP &&
-                (chatRoom.getRoomImageUrl() == null || chatRoom.getRoomImageUrl().isEmpty())) {
-            DefaultGroupImage defaultImage = getDefaultGroupImage(chatRoom.getId());
+            // 그룹 채팅방인 경우 기본 이미지 설정
+            if (chatRoom.getType() == ChatRoomType.GROUP &&
+                    (chatRoom.getRoomImageUrl() == null || chatRoom.getRoomImageUrl().trim().isEmpty())) {
+
+                try {
+                    DefaultGroupImage defaultImage = getDefaultGroupImage(chatRoom.getId());
+
+                    return ChatRoomResponseDto.builder()
+                            .id(dto.getId())
+                            .name(dto.getName())
+                            .type(dto.getType())
+                            .owner(dto.getOwner())
+                            .users(dto.getUsers())
+                            .createdAt(dto.getCreatedAt())
+                            .lastMessageAt(dto.getLastMessageAt())
+                            .isActive(dto.isActive())
+                            .roomImageUrl(defaultImage.originalUrl())
+                            .isOwner(dto.isOwner())
+                            .inviteCode(dto.getInviteCode())
+                            .inviteCodeExpiredAt(dto.getInviteCodeExpiredAt())
+                            .build();
+                } catch (Exception e) {
+                    log.error("기본 그룹 이미지 설정 실패 - 채팅방 ID: {}, 에러: {}", chatRoom.getId(), e.getMessage(), e);
+                    // 기본 이미지 설정 실패 시 원본 DTO 반환
+                    return dto;
+                }
+            }
+
+            return dto;
+        } catch (Exception e) {
+            log.error("채팅방 응답 생성 실패 - 채팅방 ID: {}, 에러: {}", chatRoom.getId(), e.getMessage(), e);
 
             return ChatRoomResponseDto.builder()
-                    .id(dto.getId())
-                    .name(dto.getName())
-                    .type(dto.getType())
-                    .owner(dto.getOwner())
-                    .users(dto.getUsers())
-                    .createdAt(dto.getCreatedAt())
-                    .lastMessageAt(dto.getLastMessageAt())
-                    .isActive(dto.isActive())
-                    .roomImageUrl(defaultImage.originalUrl())
-                    .isOwner(dto.isOwner())
-                    .inviteCode(dto.getInviteCode())
-                    .inviteCodeExpiredAt(dto.getInviteCodeExpiredAt())
+                    .id(chatRoom.getId())
+                    .name(chatRoom.getName())
+                    .type(chatRoom.getType())
+                    .owner(chatRoom.getOwner() != null ? ChatUserResponseDto.from(chatRoom.getOwner()) : null)
+                    .users(List.of())
+                    .createdAt(chatRoom.getCreatedAt())
+                    .lastMessageAt(chatRoom.getLastMessageAt())
+                    .isActive(chatRoom.isActive())
+                    .roomImageUrl(chatRoom.getRoomImageUrl())
+                    .isOwner(chatRoom.isUserOwner(currentUserId))
+                    .inviteCode(chatRoom.getInviteCode())
+                    .inviteCodeExpiredAt(chatRoom.getInviteCodeExpiredAt())
                     .build();
         }
-
-        return dto;
     }
 
     private void handleOwnerLeaving(ChatRoom chatRoom) {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -28,7 +28,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -141,7 +140,7 @@ public class ChatServiceImpl implements ChatService {
 
         return chatRooms.stream()
                 .map(chatRoom -> buildChatRoomResponse(chatRoom, userId))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -277,7 +276,7 @@ public class ChatServiceImpl implements ChatService {
 
         return searchResults.stream()
                 .map(chatRoom -> buildChatRoomResponse(chatRoom, userId))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -535,7 +534,7 @@ public class ChatServiceImpl implements ChatService {
                     }
                     return ChatUserResponseDto.from(roomUser.getUser(), thumbnailUrl);
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         dto.setUsers(users);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -17,6 +17,7 @@ import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
 import com.sonsminpark.auratalkback.domain.user.service.UserProfileImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -42,15 +43,26 @@ public class ChatServiceImpl implements ChatService {
     private final SimpMessagingTemplate messagingTemplate;
     private final UserProfileImageService userProfileImageService;
 
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
     @Override
     @Transactional
     public ChatRoomResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto, Long userId) {
         User owner = findUserById(userId);
 
+        // 채팅방 이미지 URL 생성
+        String roomImageUrl = null;
+        if (requestDto.getRoomImageS3Key() != null && !requestDto.getRoomImageS3Key().trim().isEmpty()) {
+            roomImageUrl = "https://" + bucketName + ".s3.amazonaws.com/" + requestDto.getRoomImageS3Key();
+            log.info("채팅방 이미지 설정 - S3 키: {}, URL: {}", requestDto.getRoomImageS3Key(), roomImageUrl);
+        }
+
         ChatRoom chatRoom = ChatRoom.builder()
                 .name(requestDto.getName())
                 .type(ChatRoomType.GROUP)
                 .owner(owner)
+                .roomImageUrl(roomImageUrl)
                 .isActive(true)
                 .build();
 
@@ -59,7 +71,22 @@ public class ChatServiceImpl implements ChatService {
         // 방장을 채팅방에 추가
         addUserToChatRoom(savedChatRoom, owner);
 
-        log.info("채팅방 생성 완료 - ID: {}, 방장: {}", savedChatRoom.getId(), userId);
+        // 초대할 사용자들이 있으면 추가
+        if (requestDto.getUserIds() != null && !requestDto.getUserIds().isEmpty()) {
+            for (Long inviteUserId : requestDto.getUserIds()) {
+                try {
+                    User inviteUser = findUserById(inviteUserId);
+                    addUserToChatRoom(savedChatRoom, inviteUser);
+                    sendSystemMessage(savedChatRoom, inviteUser.getNickname() + "님이 초대되었습니다.");
+                    log.info("사용자 {}를 채팅방 {}에 초대했습니다.", inviteUserId, savedChatRoom.getId());
+                } catch (Exception e) {
+                    log.warn("사용자 {} 초대 실패: {}", inviteUserId, e.getMessage());
+                }
+            }
+        }
+
+        log.info("채팅방 생성 완료 - ID: {}, 방장: {}, 이미지 설정: {}",
+                savedChatRoom.getId(), userId, roomImageUrl != null);
         return buildChatRoomResponse(savedChatRoom, userId);
     }
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -48,6 +48,20 @@ public class ChatServiceImpl implements ChatService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
+    private static final int DEFAULT_GROUP_IMAGE_COUNT = 2;
+
+    private record DefaultGroupImage(String originalUrl, String thumbnailUrl) {
+    }
+
+    private DefaultGroupImage getDefaultGroupImage(Long chatRoomId) {
+        int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+        String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+        return new DefaultGroupImage(
+                prefix + index + ".png",
+                prefix + index + "_thumb.png"
+        );
+    }
+
     @Override
     @Transactional
     public ChatRoomResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto, Long userId) {
@@ -69,6 +83,13 @@ public class ChatServiceImpl implements ChatService {
 
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
+        // 기본 이미지 설정 (사용자가 이미지를 제공하지 않은 경우)
+        if (roomImageUrl == null) {
+            DefaultGroupImage defaultImage = getDefaultGroupImage(savedChatRoom.getId());
+            savedChatRoom.updateRoomImage(defaultImage.originalUrl());
+            log.info("채팅방 기본 이미지 설정 - ID: {}, URL: {}", savedChatRoom.getId(), defaultImage.originalUrl());
+        }
+
         // 방장을 채팅방에 추가
         addUserToChatRoom(savedChatRoom, owner);
 
@@ -87,7 +108,7 @@ public class ChatServiceImpl implements ChatService {
         }
 
         log.info("채팅방 생성 완료 - ID: {}, 방장: {}, 이미지 설정: {}",
-                savedChatRoom.getId(), userId, roomImageUrl != null);
+                savedChatRoom.getId(), userId, roomImageUrl != null ? "사용자 제공" : "기본 이미지");
         return buildChatRoomResponse(savedChatRoom, userId);
     }
 
@@ -525,6 +546,27 @@ public class ChatServiceImpl implements ChatService {
 
         if (chatRoom.getOwner() != null && chatRoom.getOwner().getUserProfileImage() != null) {
             dto.setOwnerThumbnailUrl(chatRoom.getOwner().getUserProfileImage().getThumbnailImageUrl());
+        }
+
+        // 그룹 채팅방인 경우 기본 이미지 설정
+        if (chatRoom.getType() == ChatRoomType.GROUP &&
+                (chatRoom.getRoomImageUrl() == null || chatRoom.getRoomImageUrl().isEmpty())) {
+            DefaultGroupImage defaultImage = getDefaultGroupImage(chatRoom.getId());
+
+            return ChatRoomResponseDto.builder()
+                    .id(dto.getId())
+                    .name(dto.getName())
+                    .type(dto.getType())
+                    .owner(dto.getOwner())
+                    .users(dto.getUsers())
+                    .createdAt(dto.getCreatedAt())
+                    .lastMessageAt(dto.getLastMessageAt())
+                    .isActive(dto.isActive())
+                    .roomImageUrl(defaultImage.originalUrl())
+                    .isOwner(dto.isOwner())
+                    .inviteCode(dto.getInviteCode())
+                    .inviteCodeExpiredAt(dto.getInviteCodeExpiredAt())
+                    .build();
         }
 
         return dto;

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -4,7 +4,10 @@ import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatInviteRequestDto
 import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatMessageRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomCreateRequestDto;
 import com.sonsminpark.auratalkback.domain.chat.dto.request.ChatRoomUpdateRequestDto;
-import com.sonsminpark.auratalkback.domain.chat.dto.response.*;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatInviteResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatMessageResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatUserResponseDto;
 import com.sonsminpark.auratalkback.domain.chat.entity.*;
 import com.sonsminpark.auratalkback.domain.chat.exception.*;
 import com.sonsminpark.auratalkback.domain.chat.repository.ChatInvitationRepository;
@@ -50,7 +53,6 @@ public class ChatServiceImpl implements ChatService {
     public ChatRoomResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto, Long userId) {
         User owner = findUserById(userId);
 
-        // 채팅방 이미지 URL 생성
         String roomImageUrl = null;
         if (requestDto.getRoomImageS3Key() != null && !requestDto.getRoomImageS3Key().trim().isEmpty()) {
             roomImageUrl = "https://" + bucketName + ".s3.amazonaws.com/" + requestDto.getRoomImageS3Key();
@@ -72,14 +74,14 @@ public class ChatServiceImpl implements ChatService {
 
         // 초대할 사용자들이 있으면 추가
         if (requestDto.getUserIds() != null && !requestDto.getUserIds().isEmpty()) {
-            for (Long inviteUserId : requestDto.getUserIds()) {
+            List<User> inviteUsers = userRepository.findAllByIdWithProfileImage(requestDto.getUserIds());
+            for (User inviteUser : inviteUsers) {
                 try {
-                    User inviteUser = findUserById(inviteUserId);
                     addUserToChatRoom(savedChatRoom, inviteUser);
                     sendSystemMessage(savedChatRoom, inviteUser.getNickname() + "님이 초대되었습니다.");
-                    log.info("사용자 {}를 채팅방 {}에 초대했습니다.", inviteUserId, savedChatRoom.getId());
+                    log.info("사용자 {}를 채팅방 {}에 초대했습니다.", inviteUser.getId(), savedChatRoom.getId());
                 } catch (Exception e) {
-                    log.warn("사용자 {} 초대 실패: {}", inviteUserId, e.getMessage());
+                    log.warn("사용자 {} 초대 실패: {}", inviteUser.getId(), e.getMessage());
                 }
             }
         }
@@ -136,7 +138,7 @@ public class ChatServiceImpl implements ChatService {
     public List<ChatRoomResponseDto> getChatRoomsByUserId(Long userId) {
         validateUserExists(userId);
 
-        List<ChatRoom> chatRooms = chatRoomRepository.findActiveByUserId(userId);
+        List<ChatRoom> chatRooms = chatRoomRepository.findActiveByUserIdWithOwner(userId);
 
         return chatRooms.stream()
                 .map(chatRoom -> buildChatRoomResponse(chatRoom, userId))
@@ -146,7 +148,8 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional(readOnly = true)
     public ChatRoomResponseDto getChatRoomInfo(Long chatRoomId, Long userId) {
-        ChatRoom chatRoom = findChatRoomById(chatRoomId);
+        ChatRoom chatRoom = chatRoomRepository.findByIdWithOwner(chatRoomId)
+                .orElseThrow(() -> ChatRoomNotFoundException.of(chatRoomId));
 
         validateChatRoomAccess(chatRoomId, userId);
 
@@ -163,13 +166,11 @@ public class ChatServiceImpl implements ChatService {
 
         if (requestDto.getName() != null && !requestDto.getName().trim().isEmpty()) {
             chatRoom.updateName(requestDto.getName().trim());
-
             sendSystemMessage(chatRoom, "채팅방 이름이 '" + requestDto.getName() + "'로 변경되었습니다.");
         }
 
         if (requestDto.getRoomImageUrl() != null) {
             chatRoom.updateRoomImage(requestDto.getRoomImageUrl());
-
             sendSystemMessage(chatRoom, "채팅방 이미지가 변경되었습니다.");
         }
 
@@ -202,7 +203,7 @@ public class ChatServiceImpl implements ChatService {
 
         validateOwnerPermission(chatRoom, userId);
 
-        sendSystemMessage(chatRoom, "채팅방이 없습니다.");
+        sendSystemMessage(chatRoom, "채팅방이 삭제되었습니다.");
 
         // 채팅방과 관련된 모든 데이터 삭제
         chatRoomUserRepository.deleteAllByChatRoomId(chatRoomId);
@@ -229,11 +230,8 @@ public class ChatServiceImpl implements ChatService {
                 .orElseThrow(() -> InvalidChatRoomStateException.notMember());
 
         chatRoom.banUser(targetUser);
-
         sendSystemMessage(chatRoom, targetUser.getNickname() + "님이 강퇴되었습니다.");
-
         chatRoomUserRepository.delete(roomUser);
-
         sendDirectMessage(targetUser, "'" + chatRoom.getName() + "' 채팅방에서 강퇴되었습니다.");
 
         log.info("사용자 {}가 채팅방 {}에서 강퇴되었습니다.", targetUserId, chatRoomId);
@@ -257,7 +255,6 @@ public class ChatServiceImpl implements ChatService {
         }
 
         chatRoom.unbanUser(targetUser);
-
         sendSystemMessage(chatRoom, targetUser.getNickname() + "님의 강퇴가 해제되었습니다.");
 
         log.info("사용자 {}의 채팅방 {} 강퇴가 해제되었습니다.", targetUserId, chatRoomId);
@@ -298,15 +295,10 @@ public class ChatServiceImpl implements ChatService {
         ChatMessage savedMessage = chatMessageRepository.save(message);
         chatRoom.updateLastMessageAt();
 
-        String senderThumbnailUrl = null;
-        try {
-            senderThumbnailUrl = userProfileImageService.getProfileImage(sender.getId()).getThumbnailImageUrl();
-        } catch (Exception e) {
-            log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", sender.getId(), e.getMessage());
-        }
+        String senderThumbnailUrl = sender.getUserProfileImage() != null ?
+                sender.getUserProfileImage().getThumbnailImageUrl() : null;
 
         ChatMessageResponseDto responseDto = ChatMessageResponseDto.from(savedMessage, senderThumbnailUrl);
-
         messagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, responseDto);
 
         return responseDto;
@@ -317,16 +309,12 @@ public class ChatServiceImpl implements ChatService {
     public Page<ChatMessageResponseDto> getMessages(Long chatRoomId, Long userId, Pageable pageable) {
         validateChatRoomAccess(chatRoomId, userId);
 
-        Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(chatRoomId, pageable);
+        Page<ChatMessage> messages = chatMessageRepository.findByChatRoomIdWithSender(chatRoomId, pageable);
 
         return messages.map(message -> {
             String senderThumbnailUrl = null;
-            if (message.getSender() != null) {
-                try {
-                    senderThumbnailUrl = userProfileImageService.getProfileImage(message.getSender().getId()).getThumbnailImageUrl();
-                } catch (Exception e) {
-                    log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", message.getSender().getId(), e.getMessage());
-                }
+            if (message.getSender() != null && message.getSender().getUserProfileImage() != null) {
+                senderThumbnailUrl = message.getSender().getUserProfileImage().getThumbnailImageUrl();
             }
             return ChatMessageResponseDto.from(message, senderThumbnailUrl);
         });
@@ -389,7 +377,6 @@ public class ChatServiceImpl implements ChatService {
         validateChatRoomAccess(chatRoomId, userId);
         validateChatRoomActive(chatRoom);
 
-        // 이미 참여중인 사용자 확인
         if (isUserInChatRoom(chatRoomId, invitee.getId())) {
             throw InvalidChatRoomStateException.alreadyMember();
         }
@@ -523,28 +510,21 @@ public class ChatServiceImpl implements ChatService {
     private ChatRoomResponseDto buildChatRoomResponse(ChatRoom chatRoom, Long currentUserId) {
         ChatRoomResponseDto dto = ChatRoomResponseDto.from(chatRoom, currentUserId);
 
-        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomId(chatRoom.getId());
+        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomIdWithUserAndProfile(chatRoom.getId());
+
         List<ChatUserResponseDto> users = roomUsers.stream()
                 .map(roomUser -> {
-                    String thumbnailUrl = null;
-                    try {
-                        thumbnailUrl = userProfileImageService.getProfileImage(roomUser.getUser().getId()).getThumbnailImageUrl();
-                    } catch (Exception e) {
-                        log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", roomUser.getUser().getId(), e.getMessage());
-                    }
-                    return ChatUserResponseDto.from(roomUser.getUser(), thumbnailUrl);
+                    User user = roomUser.getUser();
+                    String thumbnailUrl = user.getUserProfileImage() != null ?
+                            user.getUserProfileImage().getThumbnailImageUrl() : null;
+                    return ChatUserResponseDto.from(user, thumbnailUrl);
                 })
                 .toList();
 
         dto.setUsers(users);
 
-        if (chatRoom.getOwner() != null) {
-            try {
-                String ownerThumbnailUrl = userProfileImageService.getProfileImage(chatRoom.getOwner().getId()).getThumbnailImageUrl();
-                dto.setOwnerThumbnailUrl(ownerThumbnailUrl);
-            } catch (Exception e) {
-                log.warn("방장 프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", chatRoom.getOwner().getId(), e.getMessage());
-            }
+        if (chatRoom.getOwner() != null && chatRoom.getOwner().getUserProfileImage() != null) {
+            dto.setOwnerThumbnailUrl(chatRoom.getOwner().getUserProfileImage().getThumbnailImageUrl());
         }
 
         return dto;

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -67,10 +67,9 @@ public class ChatServiceImpl implements ChatService {
     public ChatRoomResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto, Long userId) {
         User owner = findUserById(userId);
 
-        String roomImageUrl = null;
-        if (requestDto.getRoomImageS3Key() != null && !requestDto.getRoomImageS3Key().trim().isEmpty()) {
-            roomImageUrl = "https://" + bucketName + ".s3.amazonaws.com/" + requestDto.getRoomImageS3Key();
-            log.info("채팅방 이미지 설정 - S3 키: {}, URL: {}", requestDto.getRoomImageS3Key(), roomImageUrl);
+        String roomImageUrl = requestDto.getRoomImageUrl();
+        if (roomImageUrl != null && !roomImageUrl.trim().isEmpty()) {
+            log.info("채팅방 이미지 설정 - URL: {}", roomImageUrl);
         }
 
         ChatRoom chatRoom = ChatRoom.builder()
@@ -84,7 +83,7 @@ public class ChatServiceImpl implements ChatService {
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
         // 기본 이미지 설정 (사용자가 이미지를 제공하지 않은 경우)
-        if (roomImageUrl == null) {
+        if (roomImageUrl == null || roomImageUrl.trim().isEmpty()) {
             DefaultGroupImage defaultImage = getDefaultGroupImage(savedChatRoom.getId());
             savedChatRoom.updateRoomImage(defaultImage.originalUrl());
             log.info("채팅방 기본 이미지 설정 - ID: {}, URL: {}", savedChatRoom.getId(), defaultImage.originalUrl());

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -214,6 +214,30 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
+    @Transactional
+    public void unbanUser(Long chatRoomId, Long ownerId, Long targetUserId) {
+        ChatRoom chatRoom = findChatRoomById(chatRoomId);
+        User targetUser = findUserById(targetUserId);
+
+        validateOwnerPermission(chatRoom, ownerId);
+        validateChatRoomActive(chatRoom);
+
+        if (ownerId.equals(targetUserId)) {
+            throw new IllegalArgumentException("자기 자신의 강퇴를 해제할 수 없습니다.");
+        }
+
+        if (!chatRoom.isBannedUser(targetUserId)) {
+            throw new IllegalArgumentException("강퇴되지 않은 사용자입니다.");
+        }
+
+        chatRoom.unbanUser(targetUser);
+
+        sendSystemMessage(chatRoom, targetUser.getNickname() + "님의 강퇴가 해제되었습니다.");
+
+        log.info("사용자 {}의 채팅방 {} 강퇴가 해제되었습니다.", targetUserId, chatRoomId);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public List<ChatRoomResponseDto> searchChatRooms(String keyword, Long userId) {
         validateUserExists(userId);

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -55,18 +55,28 @@ public class ChatServiceImpl implements ChatService {
 
     private DefaultGroupImage getDefaultGroupImage(Long chatRoomId) {
         try {
+            // 항상 1 또는 2만 반환
             int index = (int) ((chatRoomId - 1) % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+
+            // 범위 체크
+            if (index < 1 || index > DEFAULT_GROUP_IMAGE_COUNT) {
+                index = 1; // 기본값
+            }
+
             String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
 
             log.debug("기본 그룹 이미지 생성 - 채팅방 ID: {}, 계산된 인덱스: {}", chatRoomId, index);
 
-            return new DefaultGroupImage(
-                    prefix + index + ".png",
-                    prefix + index + "_thumb.png"
-            );
-        } catch (Exception e) {
-            log.error("기본 그룹 이미지 생성 실패 - 채팅방 ID: {}, 에러: {}", chatRoomId, e.getMessage());
+            String originalUrl = prefix + index + ".png";
+            String thumbnailUrl = prefix + index + "_thumb.png";
 
+            log.debug("생성된 이미지 URL - 원본: {}, 썸네일: {}", originalUrl, thumbnailUrl);
+
+            return new DefaultGroupImage(originalUrl, thumbnailUrl);
+        } catch (Exception e) {
+            log.error("기본 그룹 이미지 생성 실패 - 채팅방 ID: {}, 에러: {}", chatRoomId, e.getMessage(), e);
+
+            // 오류 발생 시 항상 1번 이미지 사용
             String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
             return new DefaultGroupImage(
                     prefix + "1.png",

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -202,6 +202,8 @@ public class ChatServiceImpl implements ChatService {
         ChatRoomUser roomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(chatRoomId, targetUserId)
                 .orElseThrow(() -> InvalidChatRoomStateException.notMember());
 
+        chatRoom.banUser(targetUser);
+
         sendSystemMessage(chatRoom, targetUser.getNickname() + "님이 강퇴되었습니다.");
 
         chatRoomUserRepository.delete(roomUser);
@@ -220,7 +222,6 @@ public class ChatServiceImpl implements ChatService {
             return List.of();
         }
 
-        // 사용자가 참여한 채팅방 중에서 검색
         List<ChatRoom> searchResults = chatRoomRepository.searchByNameAndUserId(keyword.trim(), userId);
 
         return searchResults.stream()
@@ -343,6 +344,10 @@ public class ChatServiceImpl implements ChatService {
             throw InvalidChatRoomStateException.alreadyMember();
         }
 
+        if (chatRoom.isBannedUser(invitee.getId())) {
+            throw new IllegalArgumentException("강퇴된 사용자는 초대할 수 없습니다.");
+        }
+
         ChatInviteResponseDto inviteResponse;
         if (chatRoom.isInviteCodeValid()) {
             inviteResponse = ChatInviteResponseDto.builder()
@@ -380,6 +385,10 @@ public class ChatServiceImpl implements ChatService {
 
         if (!chatRoom.isInviteCodeValid()) {
             throw ChatInvitationException.expiredInvite();
+        }
+
+        if (chatRoom.isBannedUser(userId)) {
+            throw ChatRoomBannedException.of(chatRoom.getName());
         }
 
         User user = findUserById(userId);
@@ -431,6 +440,12 @@ public class ChatServiceImpl implements ChatService {
     }
 
     private void validateChatRoomAccess(Long chatRoomId, Long userId) {
+        ChatRoom chatRoom = findChatRoomById(chatRoomId);
+
+        if (chatRoom.isBannedUser(userId)) {
+            throw ChatRoomBannedException.of();
+        }
+
         if (!isUserInChatRoom(chatRoomId, userId)) {
             throw ChatAccessDeniedException.of("채팅방에 참여할 권한이 없습니다.");
         }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -54,12 +54,25 @@ public class ChatServiceImpl implements ChatService {
     }
 
     private DefaultGroupImage getDefaultGroupImage(Long chatRoomId) {
-        int index = Math.toIntExact(chatRoomId % DEFAULT_GROUP_IMAGE_COUNT) + 1;
-        String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
-        return new DefaultGroupImage(
-                prefix + index + ".png",
-                prefix + index + "_thumb.png"
-        );
+        try {
+            int index = (int) ((chatRoomId - 1) % DEFAULT_GROUP_IMAGE_COUNT) + 1;
+            String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+
+            log.debug("기본 그룹 이미지 생성 - 채팅방 ID: {}, 계산된 인덱스: {}", chatRoomId, index);
+
+            return new DefaultGroupImage(
+                    prefix + index + ".png",
+                    prefix + index + "_thumb.png"
+            );
+        } catch (Exception e) {
+            log.error("기본 그룹 이미지 생성 실패 - 채팅방 ID: {}, 에러: {}", chatRoomId, e.getMessage());
+
+            String prefix = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/";
+            return new DefaultGroupImage(
+                    prefix + "1.png",
+                    prefix + "1_thumb.png"
+            );
+        }
     }
 
     @Override
@@ -84,9 +97,18 @@ public class ChatServiceImpl implements ChatService {
 
         // 기본 이미지 설정 (사용자가 이미지를 제공하지 않은 경우)
         if (roomImageUrl == null || roomImageUrl.trim().isEmpty()) {
-            DefaultGroupImage defaultImage = getDefaultGroupImage(savedChatRoom.getId());
-            savedChatRoom.updateRoomImage(defaultImage.originalUrl());
-            log.info("채팅방 기본 이미지 설정 - ID: {}, URL: {}", savedChatRoom.getId(), defaultImage.originalUrl());
+            try {
+                DefaultGroupImage defaultImage = getDefaultGroupImage(savedChatRoom.getId());
+                savedChatRoom.updateRoomImage(defaultImage.originalUrl());
+                log.info("채팅방 기본 이미지 설정 완료 - ID: {}, 이미지 URL: {}",
+                        savedChatRoom.getId(), defaultImage.originalUrl());
+            } catch (Exception e) {
+                log.error("채팅방 기본 이미지 설정 실패 - ID: {}, 에러: {}", savedChatRoom.getId(), e.getMessage());
+                String fallbackUrl = "https://" + bucketName + ".s3.amazonaws.com/group-images/default/1.png";
+                savedChatRoom.updateRoomImage(fallbackUrl);
+                log.warn("채팅방 기본 이미지를 fallback으로 설정 - ID: {}, URL: {}",
+                        savedChatRoom.getId(), fallbackUrl);
+            }
         }
 
         // 방장을 채팅방에 추가

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/ChatServiceImpl.java
@@ -283,6 +283,24 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<ChatUserResponseDto> getBannedUsers(Long chatRoomId, Long userId) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdWithBannedUsers(chatRoomId)
+                .orElseThrow(() -> ChatRoomNotFoundException.of(chatRoomId));
+
+        // 방장만 차단된 사용자 목록을 조회할 수 있음
+        validateOwnerPermission(chatRoom, userId);
+
+        return chatRoom.getBannedUsers().stream()
+                .map(user -> {
+                    String thumbnailUrl = user.getUserProfileImage() != null ?
+                            user.getUserProfileImage().getThumbnailImageUrl() : null;
+                    return ChatUserResponseDto.from(user, thumbnailUrl);
+                })
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<ChatRoomResponseDto> searchChatRooms(String keyword, Long userId) {
         validateUserExists(userId);
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatService.java
@@ -1,0 +1,8 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.RandomChatStartRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.RandomChatMatchResponseDto;
+
+public interface RandomChatService {
+    RandomChatMatchResponseDto startRandomChat(Long userId, RandomChatStartRequestDto requestDto);
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatServiceImpl.java
@@ -64,7 +64,7 @@ public class RandomChatServiceImpl implements RandomChatService {
     }
 
     private User findUserById(Long userId) {
-        return userRepository.findByIdAndIsDeletedFalse(userId)
+        return userRepository.findByIdWithProfileImage(userId)
                 .orElseThrow(() -> UserNotFoundException.of(userId));
     }
 
@@ -199,9 +199,15 @@ public class RandomChatServiceImpl implements RandomChatService {
     private ChatRoomResponseDto buildChatRoomResponse(ChatRoom chatRoom, Long currentUserId) {
         ChatRoomResponseDto dto = ChatRoomResponseDto.from(chatRoom, currentUserId);
 
-        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomId(chatRoom.getId());
+        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomIdWithUserAndProfile(chatRoom.getId());
+
         List<ChatUserResponseDto> users = roomUsers.stream()
-                .map(roomUser -> buildChatUserResponse(roomUser.getUser()))
+                .map(roomUser -> {
+                    User user = roomUser.getUser();
+                    String thumbnailUrl = user.getUserProfileImage() != null ?
+                            user.getUserProfileImage().getThumbnailImageUrl() : null;
+                    return ChatUserResponseDto.from(user, thumbnailUrl);
+                })
                 .toList();
 
         dto.setUsers(users);
@@ -209,12 +215,8 @@ public class RandomChatServiceImpl implements RandomChatService {
     }
 
     private ChatUserResponseDto buildChatUserResponse(User user) {
-        String thumbnailUrl = null;
-        try {
-            thumbnailUrl = userProfileImageService.getProfileImage(user.getId()).getThumbnailImageUrl();
-        } catch (Exception e) {
-            log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", user.getId(), e.getMessage());
-        }
+        String thumbnailUrl = user.getUserProfileImage() != null ?
+                user.getUserProfileImage().getThumbnailImageUrl() : null;
         return ChatUserResponseDto.from(user, thumbnailUrl);
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/chat/service/RandomChatServiceImpl.java
@@ -1,0 +1,220 @@
+package com.sonsminpark.auratalkback.domain.chat.service;
+
+import com.sonsminpark.auratalkback.domain.chat.dto.request.RandomChatStartRequestDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatRoomResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.ChatUserResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.dto.response.RandomChatMatchResponseDto;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatRoom;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatRoomType;
+import com.sonsminpark.auratalkback.domain.chat.entity.ChatRoomUser;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomRepository;
+import com.sonsminpark.auratalkback.domain.chat.repository.ChatRoomUserRepository;
+import com.sonsminpark.auratalkback.domain.friend.repository.FriendBlockRepository;
+import com.sonsminpark.auratalkback.domain.user.entity.User;
+import com.sonsminpark.auratalkback.domain.user.exception.UserNotFoundException;
+import com.sonsminpark.auratalkback.domain.user.repository.UserRepository;
+import com.sonsminpark.auratalkback.domain.user.service.UserProfileImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RandomChatServiceImpl implements RandomChatService {
+
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final FriendBlockRepository friendBlockRepository;
+    private final UserProfileImageService userProfileImageService;
+
+    @Override
+    @Transactional
+    public RandomChatMatchResponseDto startRandomChat(Long userId, RandomChatStartRequestDto requestDto) {
+        User user = findUserById(userId);
+
+        if (!user.isRandomChatEnabled()) {
+            return createFailureResponse("랜덤 채팅이 비활성화되어 있습니다. 설정에서 활성화해주세요.");
+        }
+
+        List<String> userInterests = getUserInterests(user, requestDto);
+        if (userInterests.isEmpty()) {
+            return createFailureResponse("관심사를 설정해주세요.");
+        }
+
+        try {
+            User matchedUser = findRandomMatchingUser(userId, userInterests);
+
+            if (matchedUser != null) {
+                ChatRoom chatRoom = createRandomChatRoom(user, matchedUser);
+                return createSuccessResponse(chatRoom, matchedUser, userId);
+            } else {
+                return createFailureResponse("현재 매칭 가능한 사용자가 없습니다. 잠시 후 다시 시도해주세요.");
+            }
+        } catch (Exception e) {
+            log.error("랜덤 채팅 매칭 중 오류 발생 - 사용자: {}, 오류: {}", userId, e.getMessage(), e);
+            return createFailureResponse("매칭 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        }
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> UserNotFoundException.of(userId));
+    }
+
+    private List<String> getUserInterests(User user, RandomChatStartRequestDto requestDto) {
+        List<String> interests = requestDto.getInterests();
+        if (interests == null || interests.isEmpty()) {
+            interests = user.getInterests();
+        }
+        return interests != null ? interests : new ArrayList<>();
+    }
+
+    private User findRandomMatchingUser(Long userId, List<String> interests) {
+        Set<Long> blockedUserIds = getBlockedUserIds(userId);
+        Set<User> candidateUsers = new HashSet<>();
+
+        for (String interest : interests) {
+            try {
+                List<User> usersWithInterest = userRepository.findActiveUsersByInterest(interest);
+                candidateUsers.addAll(usersWithInterest);
+            } catch (Exception e) {
+                log.warn("관심사 '{}' 사용자 조회 실패: {}", interest, e.getMessage());
+            }
+        }
+
+        List<User> eligibleUsers = candidateUsers.stream()
+                .filter(candidate -> isEligibleForMatching(candidate, userId, blockedUserIds))
+                .toList();
+
+        return selectRandomUser(eligibleUsers);
+    }
+
+    private boolean isEligibleForMatching(User candidate, Long userId, Set<Long> blockedUserIds) {
+        if (candidate.getId().equals(userId)) {
+            return false;
+        }
+
+        if (blockedUserIds.contains(candidate.getId())) {
+            return false;
+        }
+
+        if (!candidate.isRandomChatEnabled()) {
+            return false;
+        }
+
+        if (isBlockedByUser(userId, candidate.getId())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private User selectRandomUser(List<User> eligibleUsers) {
+        if (eligibleUsers.isEmpty()) {
+            return null;
+        }
+
+        Random random = new Random();
+        return eligibleUsers.get(random.nextInt(eligibleUsers.size()));
+    }
+
+    private Set<Long> getBlockedUserIds(Long userId) {
+        try {
+            return friendBlockRepository.findBlockedUsers(userId).stream()
+                    .map(User::getId)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.warn("차단 사용자 목록 조회 실패 - 사용자: {}, 오류: {}", userId, e.getMessage());
+            return new HashSet<>();
+        }
+    }
+
+    private boolean isBlockedByUser(Long userId, Long targetUserId) {
+        try {
+            User user = findUserById(userId);
+            User targetUser = findUserById(targetUserId);
+            return friendBlockRepository.findByBlockerAndBlocked(targetUser, user).isPresent();
+        } catch (Exception e) {
+            log.warn("차단 여부 확인 실패 - 사용자: {} -> {}, 오류: {}", targetUserId, userId, e.getMessage());
+            return false;
+        }
+    }
+
+    private ChatRoom createRandomChatRoom(User user1, User user2) {
+        String chatRoomName = "랜덤 채팅 - " + user1.getNickname() + " & " + user2.getNickname();
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .name(chatRoomName)
+                .type(ChatRoomType.RANDOM)
+                .owner(user1)
+                .isActive(true)
+                .build();
+
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+        addUserToChatRoom(savedChatRoom, user1);
+        addUserToChatRoom(savedChatRoom, user2);
+
+        log.info("랜덤 채팅방 생성 완료 - ID: {}, 참여자: {} & {}",
+                savedChatRoom.getId(), user1.getId(), user2.getId());
+
+        return savedChatRoom;
+    }
+
+    private void addUserToChatRoom(ChatRoom chatRoom, User user) {
+        ChatRoomUser roomUser = ChatRoomUser.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .notificationEnabled(true)
+                .build();
+        chatRoomUserRepository.save(roomUser);
+    }
+
+    private RandomChatMatchResponseDto createSuccessResponse(ChatRoom chatRoom, User matchedUser, Long userId) {
+        return RandomChatMatchResponseDto.builder()
+                .matched(true)
+                .waiting(false)
+                .chatRoom(buildChatRoomResponse(chatRoom, userId))
+                .matchedUser(buildChatUserResponse(matchedUser))
+                .matchedAt(LocalDateTime.now())
+                .message("매칭이 완료되었습니다!")
+                .build();
+    }
+
+    private RandomChatMatchResponseDto createFailureResponse(String message) {
+        return RandomChatMatchResponseDto.builder()
+                .matched(false)
+                .waiting(false)
+                .message(message)
+                .build();
+    }
+
+    private ChatRoomResponseDto buildChatRoomResponse(ChatRoom chatRoom, Long currentUserId) {
+        ChatRoomResponseDto dto = ChatRoomResponseDto.from(chatRoom, currentUserId);
+
+        List<ChatRoomUser> roomUsers = chatRoomUserRepository.findAllByChatRoomId(chatRoom.getId());
+        List<ChatUserResponseDto> users = roomUsers.stream()
+                .map(roomUser -> buildChatUserResponse(roomUser.getUser()))
+                .toList();
+
+        dto.setUsers(users);
+        return dto;
+    }
+
+    private ChatUserResponseDto buildChatUserResponse(User user) {
+        String thumbnailUrl = null;
+        try {
+            thumbnailUrl = userProfileImageService.getProfileImage(user.getId()).getThumbnailImageUrl();
+        } catch (Exception e) {
+            log.warn("프로필 이미지 조회 실패 - 사용자: {}, 오류: {}", user.getId(), e.getMessage());
+        }
+        return ChatUserResponseDto.from(user, thumbnailUrl);
+    }
+}

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestResponseDto.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/dto/response/InterestResponseDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -29,6 +28,6 @@ public class InterestResponseDto {
     public static List<InterestResponseDto> fromList(List<Interest> interests) {
         return interests.stream()
                 .map(InterestResponseDto::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/interest/service/InterestService.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/interest/service/InterestService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -51,7 +50,7 @@ public class InterestService {
                             .interests(InterestResponseDto.fromList(interests))
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -63,7 +62,7 @@ public class InterestService {
 
         List<MyProfileResponseDto> userDtos = users.stream()
                 .map(MyProfileResponseDto::from)
-                .collect(Collectors.toList());
+                .toList();
 
         return InterestUsersResponseDto.builder()
                 .interestName(interestName)

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.sonsminpark.auratalkback.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,6 +15,13 @@ import java.util.List;
 @Builder
 @Entity
 @Table(name = "users")
+@NamedEntityGraph(
+        name = "User.withProfileAndInterests",
+        attributeNodes = {
+                @NamedAttributeNode("userProfileImage"),
+                @NamedAttributeNode("userInterests")
+        }
+)
 public class User {
 
     @Id
@@ -37,6 +45,7 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
+    @BatchSize(size = 10)
     private List<UserInterest> userInterests = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
@@ -61,7 +70,7 @@ public class User {
     @Builder.Default
     private boolean randomChatEnabled = false;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private UserProfileImage userProfileImage;
 
     public List<String> getInterests() {

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
@@ -34,4 +34,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.userProfileImage WHERE u.id = :userId")
     Optional<User> findByIdWithProfileImage(@Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userProfileImage WHERE u.id IN :userIds")
+    List<User> findAllByIdWithProfileImage(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/repository/UserRepository.java
@@ -37,4 +37,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userProfileImage WHERE u.id IN :userIds")
     List<User> findAllByIdWithProfileImage(@Param("userIds") List<Long> userIds);
+
+    Optional<User> findByEmailAndIsDeletedTrue(String email);
 }

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/scheduler/UserDeletionScheduler.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/scheduler/UserDeletionScheduler.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -38,7 +37,7 @@ public class UserDeletionScheduler {
         List<Long> userIds = keys.stream()
                 .map(key -> key.replace("USER_DELETION:", ""))
                 .map(Long::parseLong)
-                .collect(Collectors.toList());
+                .toList();
 
         log.info("익명화 처리할 사용자 수: {}", userIds.size());
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -3,10 +3,7 @@ package com.sonsminpark.auratalkback.domain.user.service;
 import com.sonsminpark.auratalkback.domain.friend.entity.FriendStatus;
 import com.sonsminpark.auratalkback.domain.friend.service.FriendService;
 import com.sonsminpark.auratalkback.domain.user.dto.request.*;
-import com.sonsminpark.auratalkback.domain.user.dto.response.LoginResponseDto;
-import com.sonsminpark.auratalkback.domain.user.dto.response.SignUpResponseDto;
-import com.sonsminpark.auratalkback.domain.user.dto.response.MyProfileResponseDto;
-import com.sonsminpark.auratalkback.domain.user.dto.response.UserProfileResponseDto;
+import com.sonsminpark.auratalkback.domain.user.dto.response.*;
 import com.sonsminpark.auratalkback.domain.user.entity.User;
 import com.sonsminpark.auratalkback.domain.user.entity.UserStatus;
 import com.sonsminpark.auratalkback.domain.user.exception.DuplicateUserException;
@@ -99,7 +96,8 @@ public class UserServiceImpl implements UserService {
 
         User savedUser = userRepository.save(user);
 
-        userProfileImageService.createDefaultProfileImage(savedUser.getId());
+        // 프로필 이미지 생성
+        ProfileImageResponseDto profileImageDto = userProfileImageService.createDefaultProfileImage(savedUser.getId());
 
         // TODO: 이메일 인증 활성화 시 아래 주석 제거하기
 //        String verificationToken = emailService.generateVerificationToken(savedUser.getEmail());
@@ -108,10 +106,23 @@ public class UserServiceImpl implements UserService {
         // 토큰에 userId 추가
         String token = jwtTokenProvider.createToken(savedUser.getEmail(), savedUser.getId());
 
+        MyProfileResponseDto userResponseDto = MyProfileResponseDto.builder()
+                .id(savedUser.getId())
+                .email(savedUser.getEmail())
+                .username(savedUser.getUsername())
+                .nickname(savedUser.getNickname())
+                .description(savedUser.getDescription())
+                .interests(savedUser.getInterests())
+                .status(savedUser.getStatus())
+                .randomChatEnabled(savedUser.isRandomChatEnabled())
+                .createdAt(savedUser.getCreatedAt())
+                .profileImage(profileImageDto)
+                .build();
+
         return SignUpResponseDto.builder()
                 .userId(savedUser.getId())
                 .token(token)
-                .user(MyProfileResponseDto.from(savedUser))
+                .user(userResponseDto)
                 .build();
     }
 

--- a/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sonsminpark/auratalkback/domain/user/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Optional;
 //import java.util.concurrent.TimeUnit;
 
 @Service
@@ -82,6 +83,56 @@ public class UserServiceImpl implements UserService {
             throw DuplicateUserException.ofEmail(signUpRequestDto.getEmail());
         }
 
+        // 30일 이내 탈퇴한 사용자가 있는지 확인
+        Optional<User> deletedUser = userRepository.findByEmailAndIsDeletedTrue(signUpRequestDto.getEmail());
+        if (deletedUser.isPresent()) {
+            User user = deletedUser.get();
+
+            // 탈퇴한 계정 복구 (30일 이내)
+            String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
+
+            user = User.builder()
+                    .id(user.getId())
+                    .email(signUpRequestDto.getEmail())
+                    .password(encodedPassword)
+                    .username("사용자명")
+                    .nickname("닉네임")
+                    .status(UserStatus.ONLINE)
+                    .isDeleted(false)
+                    .deletedAt(null)
+                    .emailVerified(true) // TODO: 이메일 인증 활성화 시 해당 줄 제거하기
+                    .userInterests(new ArrayList<>())
+                    .randomChatEnabled(false)
+                    .createdAt(user.getCreatedAt())
+                    .build();
+
+            User savedUser = userRepository.save(user);
+
+            ProfileImageResponseDto profileImageDto = userProfileImageService.createDefaultProfileImage(savedUser.getId());
+
+            String token = jwtTokenProvider.createToken(savedUser.getEmail(), savedUser.getId());
+
+            MyProfileResponseDto userResponseDto = MyProfileResponseDto.builder()
+                    .id(savedUser.getId())
+                    .email(savedUser.getEmail())
+                    .username(savedUser.getUsername())
+                    .nickname(savedUser.getNickname())
+                    .description(savedUser.getDescription())
+                    .interests(savedUser.getInterests())
+                    .status(savedUser.getStatus())
+                    .randomChatEnabled(savedUser.isRandomChatEnabled())
+                    .createdAt(savedUser.getCreatedAt())
+                    .profileImage(profileImageDto)
+                    .build();
+
+            return SignUpResponseDto.builder()
+                    .userId(savedUser.getId())
+                    .token(token)
+                    .user(userResponseDto)
+                    .build();
+        }
+
+        // 30일 후 또는 새로운 사용자 - 새 계정 생성
         String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
 
         User user = User.builder()
@@ -96,7 +147,6 @@ public class UserServiceImpl implements UserService {
 
         User savedUser = userRepository.save(user);
 
-        // 프로필 이미지 생성
         ProfileImageResponseDto profileImageDto = userProfileImageService.createDefaultProfileImage(savedUser.getId());
 
         // TODO: 이메일 인증 활성화 시 아래 주석 제거하기


### PR DESCRIPTION
## 작업 내용

### 성능 최적화
- 채팅방, 채팅 목록 조회 N+1 쿼리 문제 해결
- 그룹 채팅방에 기본 이미지 추가

### 버그 수정
- isOwner 메서드로 인한 컴파일 에러 해결
- 회원가입시 프로필 이미지 null 참조 오류 수정
- 회원탈퇴 후 재가입 불가능 문제 해결

### 새로운 기능
- 채팅방 차단된 사용자 목록 조회 API 구현
  - `GET /api/chatrooms/{chatroomId}/banned-users`

## 연관된 이슈
- #63, #64, #65, #68, #69

## 스크린샷 (선택)

## 특이사항(선택)
- 리팩토링하면서 성능 테스트 진행한 부분은 7월 9일 TID에 작성해두었습니다. (`test/chat-before-n1`과 `test/chat-after-n1`  브랜치에서 코드 확인 가능)